### PR TITLE
active_scaffold_input_plural_association html_safe output with Rails 2.3.8 & rails_xss

### DIFF
--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -139,7 +139,7 @@ module ActiveScaffold
 
         html << '</ul>'
         html << javascript_tag("new DraggableLists('#{options[:id]}')") if column.options[:draggable_lists]
-        html
+        html.html_safe
       end
 
       def active_scaffold_translated_option(column, text, value = nil)


### PR DESCRIPTION
active_scaffold_input_plural_association helper patched for rails_xss compatibility
