### PR TITLE
association_options_find now honours association :include.

### DIFF
--- a/lib/active_scaffold/helpers/association_helpers.rb
+++ b/lib/active_scaffold/helpers/association_helpers.rb
@@ -3,7 +3,9 @@ module ActiveScaffold
     module AssociationHelpers
       # Provides a way to honor the :conditions on an association while searching the association's klass
       def association_options_find(association, conditions = nil)
-        association.klass.where(conditions).where(association.options[:conditions]).all
+        relation = association.klass.where(conditions).where(association.options[:conditions])
+        relation = relation.includes(association.options[:include]) if association.options[:include]
+        relation.all
       end
 
       def association_options_count(association, conditions = nil)


### PR DESCRIPTION
Changed AssociationHelpers.association_options_find to add includes to the generated relation.

I had a model that was using an association in its to_label method. When using this model in a select list, every time the to_label function was called, another query was generated (granted, almost all were cached). As the models are also sorted using the to_label function, a lot of queries were generated.

Change is very simple - get the :include options from the association options hash, and add them to the relation if any exist.
