### PR TITLE
Fix link display if it has a authorized_for_action? method in model

### DIFF
--- a/frontends/default/views/_action_group.html.erb
+++ b/frontends/default/views/_action_group.html.erb
@@ -16,7 +16,7 @@
 	<% end %>
   <% else -%>
     <% if options[:level] == 0 %>
-      <%= "#{start_level_0_tag}#{h(render_group_action_link(link, url_options, options, record))}#{end_level_0_tag}".html_safe %>
+      <%= "#{start_level_0_tag}#{render_group_action_link(link, url_options, options, record)}#{end_level_0_tag}".html_safe %>
     <% else %>
       <%= content_tag('li', render_group_action_link(link, url_options, options, record), options[:first_action] ? {:class => 'top'}: {}) %>
     <% end %>


### PR DESCRIPTION
If model has a authorized_for_#{action}? method and action_link must be disabled, in actions column we would see html sanitized tag &lgt;a&rgt, by h helper method.
Fixed by removing h(), coz in else condition, in ul, we don't see any sanitizing
