### PR TITLE
Improved wiring of subform records

### DIFF
--- a/frontends/default/views/_form_association.html.erb
+++ b/frontends/default/views/_form_association.html.erb
@@ -3,11 +3,18 @@ parent_record = @record
 associated = column.singular_association? ? [parent_record.send(column.name)].compact : parent_record.send(column.name).to_a
 associated = associated.sort_by {|r| r.new_record? ? 99999999999 : r.id} unless column.association.options.has_key?(:order)
 if show_blank_record = column.show_blank_record?(associated)
-  associated << if column.singular_association?
-    parent_record.send("build_#{column.name}".to_sym)
-  else
-    parent_record.send(column.name).build
+  child = column.singular_association? ? parent_record.send(:"build_#{column.name}") : parent_record.send(column.name).build
+  reflection = parent_record.class.reflect_on_association(column.name)
+  if reflection && reflection.reverse && parent_record.new_record?
+    reverse_macro = child.class.reflect_on_association(reflection.reverse).macro
+    if [:has_one, :belongs_to].include?(reverse_macro) # singular
+      child.send(:"#{reflection.reverse}=", parent_record)
+    # TODO: Might want to extend with this branch in the future
+    # else # plural
+    #  child.send(:"#{reflection.reverse}") << parent_record
+    end
   end
+  associated << child
 end
 subform_div_id = "#{sub_form_id({:association => column.name, :id => parent_record.id || 99999999999})}-div" 
 -%>

--- a/lib/active_scaffold/actions/subform.rb
+++ b/lib/active_scaffold/actions/subform.rb
@@ -13,10 +13,16 @@ module ActiveScaffold::Actions
 
       # NOTE: we don't check whether the user is allowed to update this record, because if not, we'll still let them associate the record. we'll just refuse to do more than associate, is all.
       @record = @column.association.klass.find(params[:associated_id]) if params[:associated_id]
-      @record ||= if @column.singular_association?
-        @parent_record.send("build_#{@column.name}".to_sym)
-      else
-        @parent_record.send(@column.name).build
+      @record ||= @column.singular_association? ? @parent_record.send("build_#{@column.name}".to_sym) : @parent_record.send(@column.name).build
+      reflection = @parent_record.class.reflect_on_association(@column.name)
+      if reflection && reflection.reverse && @parent_record.new_record?
+        reverse_macro = @record.class.reflect_on_association(reflection.reverse).macro
+        if [:has_one, :belongs_to].include?(reverse_macro) # singular
+          @record.send(:"#{reflection.reverse}=", @parent_record)
+        # TODO: Might want to extend with this branch in the future
+        # else # plural
+        #   @record.send(:"#{reflection.reverse}") << @parent_record
+        end
       end
 
       @scope = "[#{@column.name}]"


### PR DESCRIPTION
This patch improves association wiring of subform records, the main benefit being seen in ACL.

Given the domain

```
Domain has many Records
Record belongs to Domain
```

and the following AS and CanCan ability rules

```
AS.conf.security.default_permission = false # no access by default
can :manage, Domain, :user_id => user.id # can manage my domains
can :manage, Record, :domain => {:user_id => user.id} # can manage records belonging to my domains
```

When I open "Create New" Domain form, the Records subform will be unavailable, showing small dashes "-" instead of form inputs, because the following Rails behavior:

```
# on new records build does not wire in both directions
Domain.new.records.build.domain == nil
```

My patch facilitates wiring in both directions, given that the reverse association is of singular type (`belongs_to` or `has_many`).

We only intervene on the "Create" forms, meaning `parent_record.new_record? == true` because in case of existing (saved) records ("Update" case) the reverse wiring is done by Rails just the way we expect it, and besides, assigning on existing (saved) records "instantly fires update sql without waiting for the save or update call on the parent object" and we don't want that side effect.

It remains the case of reverse (from child to parent) "many" associations that I already wrote comments about in code, and might handle if I ever encounter it.
