### PR TITLE
Fix for issue #77 (File column bridge problem)

### DIFF
--- a/lib/active_scaffold/bridges/file_column/form_ui.rb
+++ b/lib/active_scaffold/bridges/file_column/form_ui.rb
@@ -19,7 +19,7 @@ module ActiveScaffold
 
           content_tag(:div) do
             content_tag(:div) do
-              content = get_column_value(@record, column) + " #{custom_hidden_field_tag} | "
+              content = get_column_value(@record, column) + " #{custom_hidden_field_tag} | ".html_safe
               content += content_tag(:a, as_(:remove_file), {:href => '#', :onclick => remove_file_js})
               content += content_tag(:div, file_column_field("record", column.name, options), :style => "display: none")
             end           


### PR DESCRIPTION
This is a fix for issue #77, in which the file column bridge throws an error when displaying a file_column_field because the custom_hidden_field_tag is not defined.

Thanks,

Eric
