### PR TITLE
Two fixes for german locale

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,7 +1,7 @@
 de:
   time:
     formats:
-      picker: "%a, %d %b %Y %H:%M:%S"
+      picker: "%d.%m.%y %H:%M"
   active_scaffold:
     add: 'Hinzufügen'
     add_existing: 'Existierenden Eintrag hinzufügen'
@@ -65,7 +65,7 @@ de:
     between: 'Zwischen'
     contains: 'Enthält'
     begins_with: 'Beginnt'
-    ends_with: 'Ended'
+    ends_with: 'Endet'
     today: 'Heute'
     yesterday: 'Gestern'
     tomorrow: 'Morgen'


### PR DESCRIPTION
This commit corrects a spelling and fixes the datetime-picker problems mentioned here https://groups.google.com/forum/#!searchin/activescaffold/datetime/activescaffold/5Xk43wYWO_s/qsgQqJkMQskJ but never "issued".

Regards
Michael
