### PR TITLE
Fix exception when trying to render an inline scaffold from a namespaced controller

### DIFF
--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -74,8 +74,11 @@ module ActionView::Helpers #:nodoc:
         else
           content_tag(:div, :id => id, :class => 'active-scaffold-component') do
             url = url_for(url_options)
+            # parse the ActiveRecord model name from the controller path, which
+            # might be a namespaced controller (e.g., 'admin/admins')
+            model = remote_controller.to_s.sub(/.*\//, '').singularize
             content_tag(:div, :class => 'active-scaffold-header') do
-              content_tag :h2, link_to(args.first[:label] || active_scaffold_config_for(remote_controller.to_s.singularize).list.label, url, :remote => true)
+              content_tag :h2, link_to(args.first[:label] || active_scaffold_config_for(model).list.label, url, :remote => true)
             end <<
             if ActiveScaffold.js_framework == :prototype
               javascript_tag("new Ajax.Updater('#{id}', '#{url}', {method: 'get', evalScripts: true});")


### PR DESCRIPTION
Fix exception when trying to render an inline scaffold from a namespaced
controller (e.g., render :active_scaffold => 'admin/scaffolds/admins') when
using AJAX to insert the rendered scaffold instead of render_component.

As discussed here:
http://groups.google.com/group/activescaffold/browse_thread/thread/e6a7d2b705974609/6bfd935a479f44cc?show_docid=6bfd935a479f44cc&pli=1
