### PR TITLE
Enables a user to supply TinyMCE options to a text_editor form column via the "tinymce" option

### DIFF
--- a/lib/active_scaffold/bridges/tiny_mce/helpers.rb
+++ b/lib/active_scaffold/bridges/tiny_mce/helpers.rb
@@ -15,7 +15,7 @@ class ActiveScaffold::Bridges::TinyMce
       def active_scaffold_input_text_editor(column, options)
         options[:class] = "#{options[:class]} mceEditor #{column.options[:class]}".strip
 				
-				settings = column.options[:tinymce] || { theme: 'simple' }
+				settings = { :theme => 'simple' }.merge(column.options[:tinymce] || {})
 				settings = settings.to_s.gsub(/:(.+?)\=\>/, '\1:')
 				settings = "tinyMCE.settings = #{settings};"
 


### PR DESCRIPTION
Enables a user to supply TinyMCE options to a text_editor form column via the "tinymce" option. For instance, within an active_scaffold block, a user can supply:

``` ruby
class FooController < ApplicationController
  active_scaffold :foo do |conf|
    conf.columns[:bar].form_ui = :text_editor
    conf.columns[:bar].options = {
      :tinymce => { :theme => 'advanced' }
    }
  end
end
```

to use TinyMCE's advanced theme rather than the default simple theme for the "bar" column.

Thanks for all the work with AS. If you'd like anything modified, I'm happy to do so.
