### PR TITLE
Fix issue where show, mark, and other actions were validating the record...

### DIFF
--- a/lib/active_scaffold/actions/core.rb
+++ b/lib/active_scaffold/actions/core.rb
@@ -108,16 +108,16 @@ module ActiveScaffold::Actions
       @response_object = successful? ? (@record || @records) : @record.errors
     end
 
-    # Success is the existence of certain variables and the absence of errors (when applicable).
-    # Success can also be defined.
+    # Success is the existence of one or more model objects. Most actions
+    # circumvent this method by setting @success directly.
     def successful?
       if @successful.nil?
-        @records or (@record and @record.errors.count == 0 and @record.no_errors_in_associated?)
+        @record || @records
       else
         @successful
       end
     end
-
+    
     def successful=(val)
       @successful = (val) ? true : false
     end


### PR DESCRIPTION
... and its associations, which resulted in unnecessary SQL queries and object instantiation.

I noticed a problem where clicking Show was pulling down ALL of a records associations, even if they were not included in config.colums.show. It seems that the default Core::successful? method should not call @record.no_errors_in_associated?. Update and create do not rely on the successful? method and set @succesful directly. This also negatively affects volker's mark action and any other actions that do not set @successful directly.

Thanks.
