### PR TITLE
Fix bugs with datetime_picker formating

### DIFF
--- a/lib/active_scaffold/bridges/date_picker/ext.rb
+++ b/lib/active_scaffold/bridges/date_picker/ext.rb
@@ -16,7 +16,7 @@ ActiveScaffold::Config::Core.class_eval do
     # check to see if file column was used on the model
     return if date_picker_fields.empty?
     
-    # automatically set the forum_ui to a file column
+    # automatically set the forum_ui to a date_picker or datetime_picker
     date_picker_fields.each{|field|
       col_config = self.columns[field[:name]] 
       col_config.form_ui = (field[:type] == :date ? :date_picker : :datetime_picker)

--- a/lib/active_scaffold/bridges/date_picker/helper.rb
+++ b/lib/active_scaffold/bridges/date_picker/helper.rb
@@ -158,7 +158,7 @@ module ActiveScaffold::Bridges
           options = active_scaffold_input_text_options(options.merge(column.options))
           options[:class] << " #{column.search_ui.to_s}"
           options[:style] = (options[:show].nil? || options[:show]) ? nil : "display: none"
-          format = options.delete(:format) || :default
+          format = options.delete(:format) || column.form_ui == :date_picker ? :default : :picker
           datepicker_format_options(column, format, options)
           text_field_tag("#{options[:name]}[#{name}]", value ? l(value, :format => format) : nil, options.merge(:id => "#{options[:id]}_#{name}", :name => "#{options[:name]}[#{name}]"))
         end
@@ -169,7 +169,7 @@ module ActiveScaffold::Bridges
           options = active_scaffold_input_text_options(options.merge(column.options))
           options[:class] << " #{column.form_ui.to_s}"
           value = controller.class.condition_value_for_datetime(@record.send(column.name), column.form_ui == :date_picker ? :to_date : :to_time)
-          format = options.delete(:format) || :default
+          format = options.delete(:format) || column.form_ui == :date_picker ? :default : :picker
           datepicker_format_options(column, format, options)
           options[:value] = (value ? l(value, :format => format) : nil)
           text_field(:record, column.name, options)

--- a/lib/active_scaffold/finder.rb
+++ b/lib/active_scaffold/finder.rb
@@ -110,7 +110,13 @@ module ActiveScaffold
         if value.is_a? Hash
           Time.zone.local(*[:year, :month, :day, :hour, :minute, :second].collect {|part| value[part].to_i}) rescue nil
         elsif value.respond_to?(:strftime)
-          value.send(conversion)
+          if conversion == :to_time
+            # Explicitly get the localtime, because TimeWithZone#to_time in rails 3.2.3 returns UTC.
+            # https://github.com/rails/rails/pull/2453
+            value.to_time.localtime
+          else
+            value.send(conversion)
+          end
         elsif conversion == :to_date
           Date.strptime(value, I18n.t('date.formats.default')) rescue nil
         else


### PR DESCRIPTION
Fix bug where the contents of a datetime_picker textarea form field of an existing record was not correctly localized to the local timezone due to a bug/regression in rails core.

Automatically set the format of a datetime_picker column to :picker instead of
:default, because if the "time.formats.default" translation is changed from
the default value, the text field's value is set to something that is not
correctly recognized by the controller when editing and saving an existing record.
