### PR TITLE
Add HTML5 form fields

### DIFF
--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -359,6 +359,9 @@ module ActiveScaffold::DataStructures
     # to cache method to get value in list
     attr_accessor :list_method
 
+    # cache constraints for numeric columns (get in ActiveScaffold::Helpers::FormColumnHelpers::numerical_constraints_for_column)
+    attr_accessor :numerical_constraints
+
     protected
 
     def initialize_sort

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -351,39 +351,44 @@ module ActiveScaffold
 
       # Try to get numerical constraints from model's validators
       def numerical_constraints_for_column(column, options)
-        validators = column.active_record_class.validators.select do |v|
-          v.is_a? ActiveModel::Validations::NumericalityValidator and v.attributes.include? column.name
-        end
-        equal_to = validators.map{ |v| v.options[:equal_to] }.compact.first
-        # If there is equal_to constraint - use it (unless otherwise specified by user)
-        if equal_to and not (options[:min] or options[:max])
-          options[:min] = options[:max] = equal_to
-        else # find minimum and maximum from validators
-          # we can safely modify :min and :max by 1 for :greater_tnan or :less_than value only for integer values
-          only_integer = validators.map{ |v| v.options[:only_integer] }.compact.any?
-          margin = only_integer ? 1 : 0
-          # Minimum
-          unless options[:min]
-            min = validators.map{ |v| v.options[:greater_than_or_equal] }.compact.max
-            greater_than = validators.map{ |v| v.options[:greater_than] }.compact.max
-            options[:min] = [min, (greater_than.nil?? nil : greater_than+margin)].compact.max
+        if column.numerical_constraints
+          return column.numerical_constraints.merge(options)
+        else
+          validators = column.active_record_class.validators.select do |v|
+            v.is_a? ActiveModel::Validations::NumericalityValidator and v.attributes.include? column.name
           end
-          # Maximum
-          unless options[:max]
-            max = validators.map{ |v| v.options[:less_than_or_equal] }.compact.min
-            less_than = validators.map{ |v| v.options[:less_than] }.compact.min
-            options[:max] = [max, (less_than.nil?? nil : less_than-margin)].compact.min
-          end
-          # Set step = 2 for column values restricted to be odd or even (but only if minimum is set)
-          unless options[:step]
-            only_odd_valid  = validators.map{ |v| v.options[:odd] }.compact.any?
-            only_even_valid = validators.map{ |v| v.options[:even] }.compact.any?
-            if options[:min] and options[:min].respond_to? "even?" and (only_odd_valid or only_even_valid)
-              options[:step] = 2
-              options[:min] += 1 if only_odd_valid  and not options[:min].odd?
-              options[:min] += 1 if only_even_valid and not options[:min].even?
+          equal_to = validators.map{ |v| v.options[:equal_to] }.compact.first
+          # If there is equal_to constraint - use it (unless otherwise specified by user)
+          if equal_to and not (options[:min] or options[:max])
+            options[:min] = options[:max] = equal_to
+          else # find minimum and maximum from validators
+            # we can safely modify :min and :max by 1 for :greater_tnan or :less_than value only for integer values
+            only_integer = validators.map{ |v| v.options[:only_integer] }.compact.any?
+            margin = only_integer ? 1 : 0
+            # Minimum
+            unless options[:min]
+              min = validators.map{ |v| v.options[:greater_than_or_equal] }.compact.max
+              greater_than = validators.map{ |v| v.options[:greater_than] }.compact.max
+              options[:min] = [min, (greater_than.nil?? nil : greater_than+margin)].compact.max
+            end
+            # Maximum
+            unless options[:max]
+              max = validators.map{ |v| v.options[:less_than_or_equal] }.compact.min
+              less_than = validators.map{ |v| v.options[:less_than] }.compact.min
+              options[:max] = [max, (less_than.nil?? nil : less_than-margin)].compact.min
+            end
+            # Set step = 2 for column values restricted to be odd or even (but only if minimum is set)
+            unless options[:step]
+              only_odd_valid  = validators.map{ |v| v.options[:odd] }.compact.any?
+              only_even_valid = validators.map{ |v| v.options[:even] }.compact.any?
+              if options[:min] and options[:min].respond_to? "even?" and (only_odd_valid or only_even_valid)
+                options[:step] = 2
+                options[:min] += 1 if only_odd_valid  and not options[:min].odd?
+                options[:min] += 1 if only_even_valid and not options[:min].even?
+              end
             end
           end
+          column.numerical_constraints = options.select{ |key| [:min, :max, :step].include? key }
         end
         return options
       end


### PR DESCRIPTION
Hi, everyone. I've added support for some new html 5 fields and attributes. Primarily to allow browsers validate contents before form submit. And for better user experience in modern browsers.

New types: `:url`, `:email`, `:telephone`, `:number` and `:range`

They are described here: http://diveintohtml5.info/forms.html

For `:number` and `:range` AS automatically searches for constraints, defined in validators, and automatically sets `min`, `max` and `step` attributes for HTML `input` tag.

And last, I've added support for `placeholder` and `required` attributes.

None of that applies automatically. (But it's possible to make number values `:number`'s automatically, should I do so?)

Only modern browsers supports all these cool features, old browsers just renders old plain `<input type="text">` tags.

**Example 1:**

stub.rb:

``` ruby
validates :value, :numericality => {
  :greater_than_or_equal => 4,
  :even => true
}
```

stubs_controller.rb

``` ruby
conf.columns[:value].form_ui = :number
```

result (note the `min` and `step` attributes):

``` html
<input autocomplete="off" class="value-input numeric-input text-input" format="i18n_number" id="record_value_" min="4" name="record[value]" placeholder="" step="2" type="number">
```

Browser doesn't allow to send a form with wrong values.

![Spinbox control with validation](http://habrastorage.org/storage2/462/4ae/312/4624ae312c9e44d2e680f3986c694d46.png)

**Example 2**

stub.rb

``` ruby
  validates :name, :presence => true
```

stubs_controller.rb

``` ruby
conf.columns[:value].form_ui = :range
conf.columns[:value].options = {:min => -100, :max => 100, :step => 10}
```

result (note the `min`, `max` and `step` attributes):

``` html
<input autocomplete="off" class="value-input numeric-input text-input" format="i18n_number" id="record_value_" min="4" name="record[value]" placeholder="" step="2" type="number">
```

Browser doesn't allow to send form with empty required field.

![Spinbox control with validation of required text field](http://habrastorage.org/storage2/40e/8f8/a5e/40e8f8a5e87bf5db54a5b57ace1b5018.png)

**Example 3**

stubs_controller.rb

``` ruby
conf.columns[:precise].placeholder = "BE PRECISE!"
```

en.yml

``` yaml
en:
  activerecord:
    placeholder:
      stub:
        name: 'Your name, bro'
        occurs: 'Date, when it happens'
        precise: 'Precised value'
```

result
![Fields with placeholders](http://habrastorage.org/storage2/91b/3cb/0c5/91b3cb0c50bd3967773089d35f9ee9d5.png)

If pull request will be accepted, I'll update wiki.

What you think about it? Have I missed something?
