### PR TITLE
ActiveScaffold.ActionLink.Record using wrong variable in close() function

### DIFF
--- a/app/assets/javascripts/prototype/active_scaffold.js
+++ b/app/assets/javascripts/prototype/active_scaffold.js
@@ -928,7 +928,7 @@ ActiveScaffold.ActionLink.Record = Class.create(ActiveScaffold.ActionLink.Abstra
     $super();
     if (refreshed_content_or_reload) {
       if (typeof refreshed_content_or_reload == 'string') {
-        ActiveScaffold.update_row(this.target, refreshed_content_or_update);
+        ActiveScaffold.update_row(this.target, refreshed_content_or_reload);
       } else if (this.refresh_url) {
         var target = this.target;
         new Ajax.Request(this.refresh_url, {


### PR DESCRIPTION
The variable from the parameter is refreshed_content_or_reload not refreshed_content_or_update
