### PR TITLE
Removing a trailing space from the controller template

### DIFF
--- a/lib/generators/active_scaffold_controller/templates/controller.rb
+++ b/lib/generators/active_scaffold_controller/templates/controller.rb
@@ -1,4 +1,4 @@
 class <%= controller_class_name %>Controller < ApplicationController
   active_scaffold :<%= class_name.demodulize.underscore %> do |conf|
   end
-end 
+end


### PR DESCRIPTION
Hi guys.

Ultra trivial change here:

<img src="http://i.imgur.com/P0Vby.png" alt="trailing space" />

I always run vim with `:set list` on to make sure my tab-modes, etc are consistent with the project I'm working on. As a side-effect I have become allergic to trailing whitespace :-)

This pull-request removes a single trailing space from the end of the controller.rb template.
