### PR TITLE
Fix nil comparison with Fixnum exception when @page.pager.count returns nil

### DIFF
--- a/lib/active_scaffold/helpers/list_column_helpers.rb
+++ b/lib/active_scaffold/helpers/list_column_helpers.rb
@@ -266,7 +266,7 @@ module ActiveScaffold
         if active_scaffold_config.mark.mark_all_mode == :page
           all_marked = @page.items.detect { |record| !marked_records.include?(record.id) }.nil?
         else
-          all_marked = (marked_records.length >= @page.pager.count)
+          all_marked = (marked_records.length >= @page.pager.count.to_i)
         end
       end
 


### PR DESCRIPTION
When testing active_scaffold controllers within the rails functional test environment, @pager.pager.count is nil. I'm not sure why, but this change allows my tests to work and I don't think it harms anything.
