### PR TITLE
Allow the use of symbol and string in action_link config

### DIFF
--- a/lib/active_scaffold/data_structures/action_links.rb
+++ b/lib/active_scaffold/data_structures/action_links.rb
@@ -49,7 +49,7 @@ module ActiveScaffold::DataStructures
           collected = item[val]
           links << collected unless collected.nil?
         else
-          links << item if item.action == val.to_s
+          links << item if item.action.to_s == val.to_s
         end
       end
       links.first


### PR DESCRIPTION
`conf.action_links.add "demo"`
`conf.action_links.add :demo`
