### PR TITLE
Update app/assets/javascripts/prototype/active_scaffold.js

### DIFF
--- a/app/assets/javascripts/prototype/active_scaffold.js
+++ b/app/assets/javascripts/prototype/active_scaffold.js
@@ -600,7 +600,7 @@ var ActiveScaffold = {
     var toggler = toggable.previous();
     var initial_label = (options.default_visible === true) ? options.hide_label : options.show_label;
     
-    toggler.insert(' (<a class="visibility-toggle" href="#">' + initial_label + '</a>)');
+    toggler.insert(' (<a class="visibility-toggle" href="javascript:void(0)">' + initial_label + '</a>)');
     toggler.firstDescendant().observe('click', function(event) {
       var element = event.element();
       toggable.toggle(); 


### PR DESCRIPTION
In Group hide/show, when we click on show, focus is going to top of screen because href = "#"
