### PR TITLE
Update app/assets/javascripts/jquery/active_scaffold.js

### DIFF
--- a/app/assets/javascripts/jquery/active_scaffold.js
+++ b/app/assets/javascripts/jquery/active_scaffold.js
@@ -651,7 +651,7 @@ var ActiveScaffold = {
     var toggler = toggable.prev();
     var initial_label = (options.default_visible === true) ? options.hide_label : options.show_label;
     
-    toggler.append(' (<a class="visibility-toggle" href="#">' + initial_label + '</a>)');
+    toggler.append(' (<a class="visibility-toggle" href="javascript:void(0)">' + initial_label + '</a>)');
     toggler.children('a').click(function() {
       toggable.toggle(); 
       jQuery(this).html((toggable.is(':hidden')) ? options.show_label : options.hide_label);


### PR DESCRIPTION
In Group hide/show, when we click on show, focus is going to top of screen because href = "#"
