### PR TITLE
Rewrites methods using jquery.live() to use jquery.on() as they are deprecated in jquery 1.9

### DIFF
--- a/app/assets/javascripts/jquery/date_picker_bridge.js.erb
+++ b/app/assets/javascripts/jquery/date_picker_bridge.js.erb
@@ -10,7 +10,7 @@ jQuery(document).on("focus", "input.date_picker", function(){
   return true;
 });
 
-jQuery(document).on("focus", "input.date_picker", function(){
+jQuery(document).on("focus", "input.datetime_picker", function(){
   var date_picker = jQuery(this);
   if (typeof(date_picker.datetimepicker) == 'function') {
     if (!date_picker.hasClass('hasDatepicker')) {


### PR DESCRIPTION
...ecated in jquery 1.9.
- jquery api documentation for the live() method: http://api.jquery.com/live/
