### PR TITLE
Fix error with 'Add existing record' using record_select

### DIFF
--- a/app/views/active_scaffold_overrides/_form_association_footer.html.erb
+++ b/app/views/active_scaffold_overrides/_form_association_footer.html.erb
@@ -34,7 +34,7 @@ add_new_url = params_for(:action => 'edit_associated', :child_association => col
 
     <% if show_add_existing -%>
       <% if remote_controller and remote_controller.respond_to? :uses_record_select? and remote_controller.uses_record_select? -%>
-        <%= link_to_record_select as_(:add_existing), remote_controller.controller_path, :onselect => "ActiveScaffold.record_select_onselect(#{edit_associated_url.to_json}, #{active_scaffold_id.to_json}, id);" -%>
+        <%= link_to_record_select as_(:add_existing), remote_controller.controller_path, :onselect => "ActiveScaffold.record_select_onselect(#{url_for(edit_associated_url).to_json}, #{active_scaffold_id.to_json}, id);" -%>
       <% else -%>
         <% select_options = options_from_collection_for_select(sorted_association_options_find(column.association), :id, :to_label)
            add_existing_id = "#{sub_form_id(:association => column.name)}-add-existing"


### PR DESCRIPTION
In Active Scaffold 3.2.12 (possibly in d7d2a14c53df06d617439b89c9a83abc85b7f853) was introduced a bug, that fires javascript error on selecting a record from record_select in 'Add existing record'.

The reason is an URL, that in that version and above become an javascript Object (Ruby hash), not a String.

Affected versions: **rails-3.2** branch (`/frontends/default/views/_form_association_footer.html.erb:37`) version 3.2.12 and above and **master** branch (`app/views/active_scaffold_overrides/_form_association_footer.html.erb:37`).

There is a quick fix for master branch.
