### PR TITLE
Fix error with 'Add existing record' using record_select (backport)

### DIFF
--- a/frontends/default/views/_form_association_footer.html.erb
+++ b/frontends/default/views/_form_association_footer.html.erb
@@ -34,7 +34,7 @@ add_new_url = params_for(:action => 'edit_associated', :child_association => col
 
     <% if show_add_existing -%>
       <% if remote_controller and remote_controller.respond_to? :uses_record_select? and remote_controller.uses_record_select? -%>
-        <%= link_to_record_select as_(:add_existing), remote_controller.controller_path, :onselect => "ActiveScaffold.record_select_onselect(#{edit_associated_url.to_json}, #{active_scaffold_id.to_json}, id);" -%>
+        <%= link_to_record_select as_(:add_existing), remote_controller.controller_path, :onselect => "ActiveScaffold.record_select_onselect(#{url_for(edit_associated_url).to_json}, #{active_scaffold_id.to_json}, id);" -%>
       <% else -%>
         <% select_options = options_for_select(options_for_association(column.association)) 
            add_existing_id = "#{sub_form_id(:association => column.name)}-add-existing" %>


### PR DESCRIPTION
Backport of #229 for the 3.2.x versions.

Please update the gem.
