### PR TITLE
duplicate options passed to Finder#append_to_query before they are changed

### DIFF
--- a/lib/active_scaffold/finder.rb
+++ b/lib/active_scaffold/finder.rb
@@ -392,6 +392,7 @@ module ActiveScaffold
     end
     
     def append_to_query(query, options)
+      options = options.dup
       options.assert_valid_keys :where, :select, :group, :reorder, :limit, :offset, :joins, :includes, :lock, :readonly, :from, :conditions
       query = apply_conditions(query, *options.delete(:conditions)) if options[:conditions]
       options.reject{|k, v| v.blank?}.inject(query) do |query, (k, v)|


### PR DESCRIPTION
Otherwise, when paginating over the results (for example from
active_scaffold_export), the options[:conditions] is only applied for
the first page.

The Paginator uses lambda for storing the query, so calling the lambda
for subsequent pages will use the same options hash, this time without
the :conditions key.
