### PR TITLE
Don't trigger an association load when checking for unsaved associations

### DIFF
--- a/lib/active_scaffold/extensions/unsaved_associated.rb
+++ b/lib/active_scaffold/extensions/unsaved_associated.rb
@@ -47,10 +47,10 @@ class ActiveRecord::Base
   # returns false if any yield returns false.
   # returns true otherwise, even when none of the associations have been instantiated. build wrapper methods accordingly.
   def with_unsaved_associated
-    associations_for_update.all? do |association|
-      association_proxy = send(association.name)
-      if association_proxy
-        records = association_proxy
+    associations_for_update.all? do |assoc|
+      association_proxy = self.association(assoc.name)
+      if association_proxy.target.present?
+        records = association_proxy.target
         records = [records] unless records.is_a? Array # convert singular associations into collections for ease of use
         records.select {|r| r.unsaved? and not r.readonly?}.all? {|r| yield r} # must use select instead of find_all, which Rails overrides on association proxies for db access
       else


### PR DESCRIPTION
This fixes an issue where unedited associations were being loaded into memory from the db when performing an update on a record.

As a small example, consider the following:

``` ruby
class User < ActiveRecord::Base
  has_many :comments
  has_many :photos
end

class Comment < ActiveRecord::Base
  belongs_to :user
end

class Photo < ActiveRecord::Base
  belongs_to :user
end

class UsersController < ActionController::Base
  active_scaffold do |config|
    config.columns.exclude :photos
  end
end

class CommentsController < ActionController::Base
  active_scaffold do |config|
    # config stuff
  end
end
```

When editing a user with via the active scaffold pages and submitting an update, `associated_valid?` will be called on the user record.  This will iterate through the User's associations looking for unsaved records to check their validity.  

The code as it exists today would invoke both the `comments` and `photos` methods on the record.   The comments association will have been marked as loaded since the form submission would populate the target.  However, the photos association would have been touched yet as part of the form submission, so invoking the `photos` method and subsequently the `select` iterator would trigger the database call to load all of the user's photos.

This pull request alters the logic to only consider associated objects that have already been instantiated by using the actual Association proxy object to check the `target` and avoiding the possibility of populating the association from the database.
