### PR TITLE
Adds a default entry for I18n to ActiveScaffold::Bridges::DatePicker

### DIFF
--- a/lib/active_scaffold/bridges/date_picker/helper.rb
+++ b/lib/active_scaffold/bridges/date_picker/helper.rb
@@ -71,7 +71,7 @@ module ActiveScaffold::Bridges
       
       def self.datetime_options(locale)
         begin
-          rails_time_format = I18n.translate! 'time.formats.picker', :locale => locale
+          rails_time_format = I18n.translate! 'time.formats.picker', :locale => locale, :default => '%a, %d %b %Y %H:%M:%S'
           datetime_picker_options = {:ampm => false,
             :hourText => I18n.translate!('datetime.prompts.hour', :locale => locale),
             :minuteText => I18n.translate!('datetime.prompts.minute', :locale => locale),


### PR DESCRIPTION
This commit fixes asset precompile with the setting: 

``` ruby
config.assets.initialize_on_precompile = false
```

this is a common practice for heroku deploys and with this approach the I18n backend will not be available during asset precompilation. Hence the fallback to the default value is imperative.
