### PR TITLE
CRUD link ids getting extra hyphen

### DIFF
--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -368,7 +368,7 @@ module ActiveScaffold
             id = "#{column.association.name}-#{record.id}" unless record.nil?
           end
         end
-        action_id = "#{id_from_controller("#{link.controller}-") if params[:parent_controller] || link.controller != controller.controller_path}#{link.action}"
+        action_id = "#{id_from_controller("#{link.controller}-") if params[:parent_controller] || (link.controller && link.controller != controller.controller_path)}#{link.action}"
         action_link_id(action_id, id)
       end
       


### PR DESCRIPTION
We were trying to use this feature:

```
 config.create.action_after_create = :edit
```

But it didn't work. Investigation revealed that active_scaffold_overrides/on_create.js.erb calls (in Ruby) `action_link_id()` and gets back a DOM id like "as_admin__recipients-edit-4401-link". The actual link, however, had been given the id "as_admin__recipients--edit-4401-link", i.e. with an extra hyphen before the action "edit". Because of the differing ids, the javascript could not open the link.

Line 371 of lib/active_scaffold/helpers/view_helpers.rb in `get_action_link_id` seems to be the culprit:

```
action_id = "#{id_from_controller("#{link.controller}-") if params[:parent_controller] || link.controller != controller.controller_path}#{link.action}"
```

`link.controller` is nil when `link.action` is :edit (or one of the other basic CRUD values), but `controller.controller_path` isn't nil, so `id_from_controller()` gets called and passed nil, returning empty string, which then gets that extra hyphen appended to it. I've changed the if clause to be false when link.controller is nil, and this seems to solve the problem.

```
action_id = "#{id_from_controller("#{link.controller}-") if params[:parent_controller] || (link.controller && link.controller != controller.controller_path)}#{link.action}"
```

With this, the link ids are given the expected value, without the double hyphen, and so the after-create javascript can find and open them.
