### PR TITLE
fix typo

### DIFF
--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -46,7 +46,7 @@ module ActiveScaffold
                   options[:size] ||= ActionView::Helpers::InstanceTag::DEFAULT_FIELD_OPTIONS["size"]
                 end
                 options[:include_blank] = true if column.column.null and [:date, :datetime, :time].include?(column.column.type)
-                options[:value] = format_number_value((options[:object] || @raecord).send(column.name), column.options) if column.number?
+                options[:value] = format_number_value((options[:object] || @record).send(column.name), column.options) if column.number?
                 text_field(:record, column.name, options.merge(column.options))
               end
             end


### PR DESCRIPTION
i stumbled over this typo when checking out the inplace-edit-functionality and thought i'd just correct it right away. I don't know in which situation this typo actually leads to a bug currently, i could not produce an error - but it obviously was wrong.
(this typo is also present in the 3.3 gem)
