### PR TITLE
properly handle subforms for readonly HABTM associations

### DIFF
--- a/lib/active_scaffold/actions/subform.rb
+++ b/lib/active_scaffold/actions/subform.rb
@@ -2,7 +2,7 @@ module ActiveScaffold::Actions
   module Subform
     def edit_associated
       do_edit_associated
-      render :action => 'edit_associated', :formats => [:js]
+      render :action => 'edit_associated', :formats => [:js], :readonly => @column.association.options[:readonly]
     end
 
     protected

--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -226,7 +226,7 @@ module ActiveScaffold::DataStructures
     attr_writer :show_blank_record
     def show_blank_record?(associated)
       if @show_blank_record
-        return false unless self.association.klass.authorized_for?(:crud_type => :create)
+        return false unless self.association.klass.authorized_for?(:crud_type => :create) and not self.association.options[:readonly]
         self.plural_association? or (self.singular_association? and associated.blank?)
       end
     end


### PR DESCRIPTION
tested & it seems like a pretty safe change.  the scenario is roughly like:

```
class Model1 < ActiveRecord::Base
  has_and_belongs_to_many :model2s, :readonly => true
  ...
end

class Model2 < ActiveRecord::Base
  has_and_belongs_to_many :model1s
  ...
end

class Model1sController < ApplicationController
  active_scaffold :model1 do |config|
    config.columns = [..., :model2s]
  end
  ...
end
```

and without this patch the subform for editing Model1 will show a blank record and also let you modify Model2 records as you associate them.

thanks!

-Chris
chrisba@alleninstitute.org
