### PR TITLE
Fix broken sti links (because of caching)

### DIFF
--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -236,9 +236,9 @@ module ActiveScaffold
           if active_scaffold_config.cache_action_link_urls
             url = url_for(url_options)
             model = active_scaffold_config.model
-            is_sti = model.columns_hash.include?(model.inheritance_column)
-            is_sti &&= record[model.inheritance_column].present? if record
-            unless link.dynamic_parameters.is_a?(Proc) || is_sti
+            is_sti_record = record && model.columns_hash.include?(model.inheritance_column) &&
+              record[model.inheritance_column].present?
+            unless link.dynamic_parameters.is_a?(Proc) || is_sti_record
               @action_links_urls[link.name_to_cache_link_url] = url 
             end
             url


### PR DESCRIPTION
Caching action links broke links STI models.
All subsequent records have the same link, even tough they are of different descendant.

This patch disables caching of links when STI on `type: :member`.
