### PR TITLE
Require jquery/date_picker_bridge unless date_picker bridge was excluded

### DIFF
--- a/app/assets/javascripts/active_scaffold.js.erb
+++ b/app/assets/javascripts/active_scaffold.js.erb
@@ -4,7 +4,6 @@
 <% require_asset "jquery-ui-timepicker-addon" %>
 <% require_asset "jquery/active_scaffold" %>
 <% require_asset "jquery/jquery.editinplace" %>
-<% require_asset "jquery/date_picker_bridge" %>
 <% require_asset "jquery/draggable_lists" %>
 <% when :prototype %>
 <% require_asset "effects" %>

--- a/lib/active_scaffold/bridges/date_picker.rb
+++ b/lib/active_scaffold/bridges/date_picker.rb
@@ -1,12 +1,15 @@
 module ActiveScaffold::Bridges
   class DatePicker < ActiveScaffold::DataStructures::Bridge
     autoload :Helper, 'active_scaffold/bridges/date_picker/helper'
+
     def self.install
       require File.join(File.dirname(__FILE__), "date_picker/ext.rb")
     end
+
     def self.install?
       ActiveScaffold.js_framework == :jquery
     end
+
     def self.localization
       "jQuery(function($){
   if (typeof($.datepicker) === 'object') {
@@ -18,6 +21,10 @@ module ActiveScaffold::Bridges
     $.timepicker.setDefaults($.timepicker.regional['#{::I18n.locale}']);
   }
 });\n"        
+    end
+
+    def self.javascripts
+      ['jquery/date_picker_bridge']
     end
   end
 end


### PR DESCRIPTION
Fixed error when exclude date_picker bridge.

``` ruby
  # initializer
  ActiveScaffold.exclude_bridges = [:date_picker]
```

Error

```
  undefined method `localization' for nil:NilClass (in .../active_scaffold-505e819b79ec/app/assets/javascripts/jquery/date_picker_bridge.js.erb)
```
