### PR TITLE
Always create subrecords via build_associated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 - Display count items when pagination is disabled
 - Check security in column groups in forms
 - Add refresh_link option to :select form_ui
+- Always create subrecords via build_associated
 
 = 3.3.3
 - Allow to override select options in active_scaffold_search_select

--- a/lib/active_scaffold/attribute_params.rb
+++ b/lib/active_scaffold/attribute_params.rb
@@ -173,7 +173,7 @@ module ActiveScaffold
       if params.has_key? klass.primary_key
         record_from_current_or_find(klass, params[klass.primary_key], current)
       elsif klass.authorized_for?(:crud_type => :create)
-        parent_column.association.klass.new
+        build_associated(parent_column.association, parent_record)
       end
     end
 


### PR DESCRIPTION
One liner, should be obvious.
