### PR TITLE
Fix "Create is not enabled" error in update_respond_to_html

### DIFF
--- a/lib/active_scaffold/actions/update.rb
+++ b/lib/active_scaffold/actions/update.rb
@@ -34,7 +34,7 @@ module ActiveScaffold::Actions
     end
     def update_respond_to_html
       if params[:iframe]=='true' # was this an iframe post ?
-        do_refresh_list if successful? && active_scaffold_config.create.refresh_list && !render_parent?
+        do_refresh_list if successful? && active_scaffold_config.update.refresh_list && !render_parent?
         responds_to_parent do
           render :action => 'on_update', :formats => [:js], :layout => false
         end


### PR DESCRIPTION
Method update_respond_to_html in ActiveScaffold::Actions::Update refers to 

```
active_scaffold_config.create.refresh_list
```

This leads to a "Create is not enabled..." errors in controllers where create action is disabled.
