### PR TITLE
fix RJS error in on_update.js.erb, use to_param

### DIFF
--- a/app/views/active_scaffold_overrides/on_update.js.erb
+++ b/app/views/active_scaffold_overrides/on_update.js.erb
@@ -1,5 +1,5 @@
 try {
-<% form_selector = "#{element_form_id(:action => :update, :id => @record.try(:id) || params[:id])}" %>
+<% form_selector = "#{element_form_id(:action => :update, :id => @record.try(:to_param) || params[:id])}" %>
 var action_link = ActiveScaffold.find_action_link('<%= form_selector %>');
 action_link.update_flash_messages('<%= escape_javascript(render(:partial => 'messages')) %>');
 <% if controller.send :successful? %>


### PR DESCRIPTION
For models where id != to_param the form selector in on_update.js.erb does not match anything. 

This leads to an RJS error: "TypeError: Cannot call method 'update_flash_messages' of null". Replacing id with to_param in the selector fixes this.
