### PR TITLE
Use id instead of to_param for update form id

### DIFF
--- a/app/views/active_scaffold_overrides/_base_form.html.erb
+++ b/app/views/active_scaffold_overrides/_base_form.html.erb
@@ -14,10 +14,16 @@
    method ||= :post
    cancel_link = true if cancel_link.nil?
    submit_text ||= form_action
-   body_partial ||= 'form' %>
+   body_partial ||= 'form'
+   if form_action == :update
+     form_id = element_form_id(:action => :update, :id => @record.try(:id))
+   else
+     form_id = element_form_id(:action => form_action)
+   end
+%>
 <%=
 options = {:onsubmit => onsubmit,
-           :id => element_form_id(:action => form_action),
+           :id => form_id,
            :multipart => multipart,
            :class => "as_form #{form_action.to_s}",
            :method => method,

--- a/app/views/active_scaffold_overrides/on_update.js.erb
+++ b/app/views/active_scaffold_overrides/on_update.js.erb
@@ -1,5 +1,5 @@
 try {
-<% form_selector = "#{element_form_id(:action => :update, :id => @record.try(:to_param) || params[:id])}" %>
+<% form_selector = "#{element_form_id(:action => :update, :id => @record.try(:id) || params[:id])}" %>
 var action_link = ActiveScaffold.find_action_link('<%= form_selector %>');
 action_link.update_flash_messages('<%= escape_javascript(render(:partial => 'messages')) %>');
 <% if controller.send :successful? %>


### PR DESCRIPTION
The value returned by record.to_param can change during an update action. Unlike record.id it can't be generally  relied on in on_update.js.erb to find the form. 

For example if record.name is part of to_param and the user edits the name and saves, on_update.js will show an RJS error alert.

Here is one possible way to solve the problem.
