### PR TITLE
Add primary key to 'ORDER BY' clause, because with POSTGRES rows are ret...

### DIFF
--- a/lib/active_scaffold/data_structures/sorting.rb
+++ b/lib/active_scaffold/data_structures/sorting.rb
@@ -109,7 +109,10 @@ module ActiveScaffold::DataStructures
         order << Array(sql).map {|column| "#{column} #{sort_direction}"}.join(', ')
       end
 
-      order unless order.empty?
+      unless order.empty?
+        order << ' id ASC ' 
+        order
+      end
     end
 
     protected


### PR DESCRIPTION
Add primary key to 'ORDER BY' clause, because with POSTGRES rows are returned in a not deterministic way if sorting field is not unique. 

For further explanation of this unexpected behavior see:

http://www.postgresql.org/message-id/4A0C62B1.1060208@etf.bg.ac.yu and
http://stackoverflow.com/questions/11904766/strange-ordering-bug-is-it-a-bug-in-postgres-when-ordering-two-columns-with-i
