### PR TITLE
Use correct row id in row.js.erb

### DIFF
--- a/app/views/active_scaffold_overrides/row.js.erb
+++ b/app/views/active_scaffold_overrides/row.js.erb
@@ -1,2 +1,2 @@
-ActiveScaffold.update_row('<%= element_row_id(:action => :list) %>', '<%= escape_javascript render('list_record', :record => @record) %>');
+ActiveScaffold.update_row('<%= element_row_id(:action => :list, :id => @record.try(:id)) %>', '<%= escape_javascript render('list_record', :record => @record) %>');
 <%= render :partial => 'update_calculations', :formats => [:js] %>


### PR DESCRIPTION
For models where to_param != id row.js.erb does not find the correct row to update. Adding id parameter to the call to element_row_id solves this.
