### PR TITLE
Work around removed attribute_methods_generated? in Rails 4.0.4

### DIFF
--- a/lib/active_scaffold/core.rb
+++ b/lib/active_scaffold/core.rb
@@ -89,7 +89,13 @@ module ActiveScaffold
 
         # defines the attribute read methods on the model, so record.send() doesn't find protected/private methods instead
         klass = self.active_scaffold_config.model
-        klass.define_attribute_methods unless klass.attribute_methods_generated?
+        # Rails 4.0.4 has removed attribute_methods_generated,
+        # and made define_attribute_methods threadsave to call multiple times.
+        # Check for that here.
+        if ((Rails::VERSION::MAJOR == 4) && !klass.respond_to?(:attribute_methods_generated)) ||
+            !klass.attribute_methods_generated?
+          klass.define_attribute_methods
+        end
         # include the rest of the code into the controller: the action core and the included actions
         module_eval do
           include ActiveScaffold::Finder


### PR DESCRIPTION
Rails 4.0.4 killed attribute_methods_generated?, but made define_attribute_methods threadsafe and save to call multiple times.
