### PR TITLE
Fixes not null boolean columns

### DIFF
--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -350,7 +350,7 @@ module ActiveScaffold::DataStructures
       self.css_class = ''
       self.required = active_record_class.validators_on(self.name).any? do |val|
         !val.options[:if] && !val.options[:unless] && (ActiveModel::Validations::PresenceValidator === val ||
-          (ActiveModel::Validations::InclusionValidator === val && !val.options[:allow_nil] && !val.options[:allow_blank])
+          (ActiveModel::Validations::InclusionValidator === val && !val.options[:allow_nil] && !val.options[:allow_blank] && !(@form_ui == :checkbox && [[true, false], [false, true]].include?(val.send(:delimiter))))
         )
       end
       self.sort = true


### PR DESCRIPTION
When a boolean field is validated with inclusion [true, false] or
[false, true] it should not be marked as required.
refs #332
