### PR TITLE
Update localize.rb

### DIFF
--- a/lib/active_scaffold/extensions/localize.rb
+++ b/lib/active_scaffold/extensions/localize.rb
@@ -1,7 +1,7 @@
 class Object
   def as_(key, options = {})
     unless key.blank?
-      text = I18n.translate "#{key}", {:scope => [:active_scaffold, *options.delete(:scope)], :default => key.is_a?(String) ? key : key.to_s.titleize}.merge(options)
+      text = I18n.translate("#{key}", {:scope => [:active_scaffold, *options.delete(:scope)], :default => key.is_a?(String) ? key : key.to_s.titleize}.merge(options)).html_safe
       # text = nil if text.include?('translation missing:')
     end
     text ||= key 


### PR DESCRIPTION
Allows for contents such as "&lt;i class='fa fa-filter'&gt;&lt;/i&gt; Filters &lt;i class='fa fa-caret-down'&gt;&lt;/i&gt;" to be placed in the locale yml.
