### PR TITLE
Fixed IE8 error when updating a record

### DIFF
--- a/app/assets/javascripts/jquery/active_scaffold.js
+++ b/app/assets/javascripts/jquery/active_scaffold.js
@@ -495,7 +495,7 @@ var ActiveScaffold = {
   replace: function(element, html) {
     if (typeof(element) == 'string') element = '#' + element; 
     element = jQuery(element);
-    var new_element = typeof(html) == 'string' ? jQuery.parseHTML($.trim(html), true) : html;
+    var new_element = typeof(html) == 'string' ? jQuery.parseHTML(jQuery.trim(html), true) : html;
     new_element = jQuery(new_element);
     if (element.length) {
       element.replaceWith(new_element);


### PR DESCRIPTION
IE8 displays an RJS error when a user updates a record. That's because IE8 doesn't support the JavaScript trim() function, so I propose to use the jQuery $.trim function instead.
