### PR TITLE
remove `params[:id].to_i > 0` check

### DIFF
--- a/lib/active_scaffold/actions/list.rb
+++ b/lib/active_scaffold/actions/list.rb
@@ -151,11 +151,11 @@ module ActiveScaffold::Actions
     def process_action_link_action(render_action = :action_update, crud_type_or_security_options = nil)
       if request.get?
         # someone has disabled javascript, we have to show confirmation form first
-        @record = find_if_allowed(params[:id], :read) if params[:id] && params[:id].to_i > 0
+        @record = find_if_allowed(params[:id], :read) if params[:id]
         respond_to_action(:action_confirmation)
       else
         @action_link = active_scaffold_config.action_links[action_name]
-        if params[:id] && params[:id].to_i > 0
+        if params[:id]
           crud_type_or_security_options ||= (request.post? || request.put?) ? :update : :delete
           get_row(crud_type_or_security_options)
           unless @record.nil?

--- a/lib/active_scaffold/actions/show.rb
+++ b/lib/active_scaffold/actions/show.rb
@@ -11,7 +11,7 @@ module ActiveScaffold::Actions
         do_show
         respond_to_action(:show)
       else
-        @record = find_if_allowed(params[:id], :read) if params[:id] && params[:id].to_i > 0
+        @record = find_if_allowed(params[:id], :read) if params[:id]
         action_confirmation_respond_to_html(:destroy)
       end
     end


### PR DESCRIPTION
The `params[:id].to_i > 0` check is not necessary,

if a table primary key is not integer, then `process_action_link_action` will not receive @record.
