### PR TITLE
inverted comparison to avoid typecast errors

### DIFF
--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -521,7 +521,7 @@ module ActiveScaffold
 
       def column_empty?(column_value)
         empty = column_value.nil?
-        empty ||= column_value != false && column_value.blank?
+        empty ||= false != column_value && column_value.blank?
         empty ||= ['&nbsp;', active_scaffold_config.list.empty_field_text].include? column_value if String === column_value
         return empty
       end


### PR DESCRIPTION
Forcing boolean to be cast to integer when comparing to column_value of IPAddr class (PostgreSQL inet column type) resulted in "undefined method `to_i' for false:FalseClass". Inverting the comparison from: column_value != false, to: false != column_value, forced the typecast to the way around.
