### PR TITLE
Replace $ with jQuery better compatibility

### DIFF
--- a/app/assets/javascripts/jquery/active_scaffold.js
+++ b/app/assets/javascripts/jquery/active_scaffold.js
@@ -433,7 +433,7 @@ var ActiveScaffold = {
     jQuery('.as-js-button', element).show();
   },
   load_embedded: function(element) {
-    $('.active-scaffold-component .load-embedded', element).each(function(index, item) {
+    jQuery('.active-scaffold-component .load-embedded', element).each(function(index, item) {
       item = jQuery(item);
       item.closest('.active-scaffold-component').load(item.attr('href'), function() {
         jQuery(this).trigger('as:element_updated');


### PR DESCRIPTION
All the calls in this section use `jQuery()` rather than `$()`. `jQuery()` has better compatibility since `$()` will break if using `jQuery.noConflict()`. This change makes this more consistent and compatible.
