### PR TITLE
Make :test a default rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.0.0
   - rbx-2.2
   - jruby-19mode
-script: bundle exec rake test
 gemfile:
   - gemfiles/Gemfile.rails-3.2.x
   - gemfiles/Gemfile.rails-4.0.x

--- a/Rakefile
+++ b/Rakefile
@@ -26,3 +26,5 @@ Rake::RDocTask.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('README*')
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
+
+task :default => :test


### PR DESCRIPTION
Travis CI runs rake by default to execute your tests.
You could use only `rake` to run all test suite.