### PR TITLE
update tinyMCE bridge with changed commands and theme

### DIFF
--- a/app/assets/javascripts/jquery/tiny_mce_bridge.js
+++ b/app/assets/javascripts/jquery/tiny_mce_bridge.js
@@ -1,7 +1,7 @@
 var action_link_close = ActiveScaffold.ActionLink.Abstract.prototype.close;       
 ActiveScaffold.ActionLink.Abstract.prototype.close = function() {
   jQuery(this.adapter).find('textarea.mceEditor').each(function(index, elem) {         
-    tinyMCE.execCommand('mceRemoveControl', false, jQuery(elem).attr('id'));
+    tinyMCE.execCommand('mceRemoveEditor', false, jQuery(elem).attr('id'));
   });
   action_link_close.apply(this);  
 };

--- a/app/assets/javascripts/prototype/tiny_mce_bridge.js
+++ b/app/assets/javascripts/prototype/tiny_mce_bridge.js
@@ -1,7 +1,7 @@
 var action_link_close = ActiveScaffold.ActionLink.Abstract.prototype.close;
 ActiveScaffold.ActionLink.Abstract.prototype.close = function() {
   this.adapter.select('textarea.mceEditor').each(function(elem) {
-    tinyMCE.execCommand('mceRemoveControl', false, elem.id);
+    tinyMCE.execCommand('mceRemoveEditor', false, elem.id);
   }); 
   action_link_close.apply(this);
 };

--- a/lib/active_scaffold/bridges/tiny_mce/helpers.rb
+++ b/lib/active_scaffold/bridges/tiny_mce/helpers.rb
@@ -15,22 +15,22 @@ class ActiveScaffold::Bridges::TinyMce
       def active_scaffold_input_text_editor(column, options)
         options[:class] = "#{options[:class]} mceEditor #{column.options[:class]}".strip
 
-        settings = {:theme => 'simple'}.merge(column.options[:tinymce] || {})
+        settings = {:theme => 'modern'}.merge(column.options[:tinymce] || {})
         settings = settings.to_json
         settings = "tinyMCE.settings = #{settings};"
 
         html = []
         html << send(override_input(:textarea), column, options)
-        html << javascript_tag(settings + "tinyMCE.execCommand('mceAddControl', false, '#{options[:id]}');") if request.xhr? || params[:iframe]
+        html << javascript_tag(settings + "tinyMCE.execCommand('mceAddEditor', false, '#{options[:id]}');") if request.xhr? || params[:iframe]
         html.join "\n"
       end
 
       def onsubmit_with_tiny_mce
         case ActiveScaffold.js_framework
         when :jquery
-          submit_js = 'tinyMCE.triggerSave();jQuery(\'textarea.mceEditor\').each(function(index, elem) { tinyMCE.execCommand(\'mceRemoveControl\', false, jQuery(elem).attr(\'id\')); });'
+          submit_js = 'tinyMCE.triggerSave();jQuery(\'textarea.mceEditor\').each(function(index, elem) { tinyMCE.execCommand(\'mceRemoveEditor\', false, jQuery(elem).attr(\'id\')); });'
         when :prototype
-          submit_js = 'tinyMCE.triggerSave();this.select(\'textarea.mceEditor\').each(function(elem) { tinyMCE.execCommand(\'mceRemoveControl\', false, elem.id); });'
+          submit_js = 'tinyMCE.triggerSave();this.select(\'textarea.mceEditor\').each(function(elem) { tinyMCE.execCommand(\'mceRemoveEditor\', false, elem.id); });'
         end
         [onsubmit_without_tiny_mce, submit_js].compact.join ';'
       end

--- a/test/bridges/tiny_mce_test.rb
+++ b/test/bridges/tiny_mce_test.rb
@@ -15,7 +15,7 @@ class TinyMceTest < ActionView::TestCase
     @record = Company.new
     expects(:request).returns(stub(:xhr? => true))
 
-    assert_dom_equal %{<textarea name=\"record[name]\" class=\"name-input mceEditor\" id=\"record_name\">\n</textarea>\n<script#{' type="text/javascript"' if Rails::VERSION::MAJOR < 4}>\n//<![CDATA[\ntinyMCE.settings = {\"theme\":\"simple\"};tinyMCE.execCommand('mceAddControl', false, 'record_name');\n//]]>\n</script>}, active_scaffold_input_text_editor(config.columns[:name], :name => 'record[name]', :id => 'record_name', :class => 'name-input', :object => @record)
+    assert_dom_equal %{<textarea name=\"record[name]\" class=\"name-input mceEditor\" id=\"record_name\">\n</textarea>\n<script#{' type="text/javascript"' if Rails::VERSION::MAJOR < 4}>\n//<![CDATA[\ntinyMCE.settings = {\"theme\":\"simple\"};tinyMCE.execCommand('mceAddEditor', false, 'record_name');\n//]]>\n</script>}, active_scaffold_input_text_editor(config.columns[:name], :name => 'record[name]', :id => 'record_name', :class => 'name-input', :object => @record)
   end
 
   protected


### PR DESCRIPTION
pull request created as per your request on the ActiveScaffold : Ruby on Rails Gem Google group regarding TinyMCE.

Using rails 4.2,  tinymce-rails (4.1.6) and active_scaffold (3.4.18.1), in order to get the tinymce bridge to work, I had to make the following changes to active_scaffold:

In TinyMCE 4.x mceRemoveControl and mceAddControl have been removed. 
Search and replace all occurrences with mceRemoveEditor and mceAddEditor instead.

The standard theme is not part of the tinymce-rails gem.
In lib/active_scaffold/bridges/tiny_mce/helpers.rb, change line 18 :
        settings = {:theme => 'standard'}.merge(column.options[:tinymce] || {})
to
        settings = {:theme => 'modern'}.merge(column.options[:tinymce] || {})