### PR TITLE
Use parent controller config to get parent model

### DIFF
--- a/lib/active_scaffold/actions/core.rb
+++ b/lib/active_scaffold/actions/core.rb
@@ -97,7 +97,8 @@ module ActiveScaffold::Actions
     end
 
     def set_parent(record)
-      parent_model = params[:parent_controller].singularize.camelize.constantize
+      controller = "#{params[:parent_controller].camelize}Controller".constantize
+      parent_model = controller.active_scaffold_config.model
       child_association = params[:child_association].presence || @scope.split(']').first.sub(/^\[/, '')
       association = parent_model.reflect_on_association(child_association.to_sym).try(:reverse)
       return if association.nil?


### PR DESCRIPTION
Currently set_parent uses the parent controller name to set the parent model. 

This does not work correctly when the controller is not named according to the standard convention (for example when the parent controller is in a namespace and its model is not).

Changed to look up the parent model from the parent controller's active_scaffold_config.