### PR TITLE
Using new syntax: *_action instead of *_filter

### DIFF
--- a/lib/active_scaffold/actions/common_search.rb
+++ b/lib/active_scaffold/actions/common_search.rb
@@ -3,9 +3,9 @@ module ActiveScaffold::Actions
     def self.included(base)
       unless base < InstanceMethods
         base.send :include, InstanceMethods
-        base.before_filter :search_authorized_filter, :only => :show_search
-        base.before_filter :store_search_params_into_session, :only => [:index]
-        base.before_filter :do_search, :only => [:index]
+        base.before_action :search_authorized_filter, :only => :show_search
+        base.before_action :store_search_params_into_session, :only => [:index]
+        base.before_action :do_search, :only => [:index]
         base.helper_method :search_params
       end
     end

--- a/lib/active_scaffold/actions/core.rb
+++ b/lib/active_scaffold/actions/core.rb
@@ -2,11 +2,11 @@ module ActiveScaffold::Actions
   module Core
     def self.included(base)
       base.class_eval do
-        before_filter :handle_user_settings
-        before_filter :check_input_device
-        before_filter :register_constraints_with_action_columns, :unless => :nested?
-        after_filter :clear_flashes
-        after_filter :clear_storage
+        before_action :handle_user_settings
+        before_action :check_input_device
+        before_action :register_constraints_with_action_columns, :unless => :nested?
+        after_action :clear_flashes
+        after_action :clear_storage
         rescue_from ActiveScaffold::RecordNotAllowed, ActiveScaffold::ActionNotAllowed, :with => :deny_access
       end
       base.helper_method :successful?

--- a/lib/active_scaffold/actions/create.rb
+++ b/lib/active_scaffold/actions/create.rb
@@ -1,7 +1,7 @@
 module ActiveScaffold::Actions
   module Create
     def self.included(base)
-      base.before_filter :create_authorized_filter, :only => [:new, :create]
+      base.before_action :create_authorized_filter, :only => [:new, :create]
     end
 
     def new

--- a/lib/active_scaffold/actions/delete.rb
+++ b/lib/active_scaffold/actions/delete.rb
@@ -1,7 +1,7 @@
 module ActiveScaffold::Actions
   module Delete
     def self.included(base)
-      base.before_filter :delete_authorized_filter, :only => [:destroy]
+      base.before_action :delete_authorized_filter, :only => [:destroy]
     end
 
     def destroy

--- a/lib/active_scaffold/actions/list.rb
+++ b/lib/active_scaffold/actions/list.rb
@@ -1,7 +1,7 @@
 module ActiveScaffold::Actions
   module List
     def self.included(base)
-      base.before_filter :list_authorized_filter, :only => :index
+      base.before_action :list_authorized_filter, :only => :index
       base.helper_method :list_columns
     end
 

--- a/lib/active_scaffold/actions/mark.rb
+++ b/lib/active_scaffold/actions/mark.rb
@@ -1,8 +1,8 @@
 module ActiveScaffold::Actions
   module Mark
     def self.included(base)
-      base.before_filter :mark_authorized?, :only => :mark
-      base.before_filter :assign_marked_records_to_model
+      base.before_action :mark_authorized?, :only => :mark
+      base.before_action :assign_marked_records_to_model
       base.helper_method :marked_records
     end
 

--- a/lib/active_scaffold/actions/nested.rb
+++ b/lib/active_scaffold/actions/nested.rb
@@ -4,11 +4,11 @@ module ActiveScaffold::Actions
     def self.included(base)
       super
       base.module_eval do
-        before_filter :set_nested
-        before_filter :configure_nested
+        before_action :set_nested
+        before_action :configure_nested
         include ActiveScaffold::Actions::Nested::ChildMethods if active_scaffold_config.model.reflect_on_all_associations.any? { |a| a.macro == :has_and_belongs_to_many }
       end
-      base.before_filter :include_habtm_actions
+      base.before_action :include_habtm_actions
       base.helper_method :nested
       base.helper_method :nested_parent_record
     end

--- a/lib/active_scaffold/actions/show.rb
+++ b/lib/active_scaffold/actions/show.rb
@@ -1,7 +1,7 @@
 module ActiveScaffold::Actions
   module Show
     def self.included(base)
-      base.before_filter :show_authorized_filter, :only => :show
+      base.before_action :show_authorized_filter, :only => :show
     end
 
     def show

--- a/lib/active_scaffold/actions/update.rb
+++ b/lib/active_scaffold/actions/update.rb
@@ -1,7 +1,7 @@
 module ActiveScaffold::Actions
   module Update
     def self.included(base)
-      base.before_filter :update_authorized_filter, :only => [:edit, :update]
+      base.before_action :update_authorized_filter, :only => [:edit, :update]
       base.helper_method :update_refresh_list?
     end
 

--- a/lib/active_scaffold/active_record_permissions.rb
+++ b/lib/active_scaffold/active_record_permissions.rb
@@ -26,7 +26,7 @@ module ActiveScaffold
     module ModelUserAccess
       module Controller
         def self.included(base)
-          base.prepend_before_filter :assign_current_user_to_models
+          base.prepend_before_action :assign_current_user_to_models
         end
 
         # We need to give the ActiveRecord classes a handle to the current user. We don't want to just pass the object,

--- a/lib/active_scaffold/bridges/cancan/cancan_bridge.rb
+++ b/lib/active_scaffold/bridges/cancan/cancan_bridge.rb
@@ -62,7 +62,7 @@ module ActiveScaffold::Bridges
       module Controller
         extend ActiveSupport::Concern
         included do
-          prepend_before_filter :assign_current_ability_to_models
+          prepend_before_action :assign_current_ability_to_models
         end
 
         # We need to give the ActiveRecord classes a handle to the current ability. We don't want to just pass the object,

--- a/test/misc/attribute_params_test.rb
+++ b/test/misc/attribute_params_test.rb
@@ -431,7 +431,7 @@ end
 
 class Controller
   def self.helper_method(*); end
-  def self.before_filter(*); end
+  def self.before_action(*); end
 
   include ActiveScaffold::Core
   include ActiveScaffold::Helpers::ControllerHelpers

--- a/test/misc/constraints_test.rb
+++ b/test/misc/constraints_test.rb
@@ -83,7 +83,7 @@ end
 
 class ConstraintsTestObject
   # stub out what the mixin expects to find ...
-  def self.before_filter(*); end
+  def self.before_action(*); end
   def self.helper_method(*); end
   attr_accessor :active_scaffold_preload
   attr_accessor :active_scaffold_references


### PR DESCRIPTION
Old syntax is deprecated in Rails 5.0 and will be removed in Rails 5.1.
See https://github.com/rails/rails/blob/master/actionpack/lib/abstract_controller/callbacks.rb
The same as in https://github.com/activescaffold/active_scaffold/pull/451 but rebased on `next` branch.