### PR TITLE
Fix Javascript escaping in :dont_close path of on_update

### DIFF
--- a/app/views/active_scaffold_overrides/on_update.js.erb
+++ b/app/views/active_scaffold_overrides/on_update.js.erb
@@ -3,12 +3,14 @@ try {
 var action_link = ActiveScaffold.find_action_link('<%= form_selector %>');
 action_link.update_flash_messages('<%= escape_javascript(render(:partial => 'messages')) %>');
 <% if successful? %>
-  <% if params[:dont_close] %>
+  <% if params[:dont_close] == 'true' %>
     <% row_selector = element_row_id(:action => :list, :id => @record.id) %>
     ActiveScaffold.update_row('<%= row_selector %>', '<%= escape_javascript(render(:partial => 'list_record', :locals => {:record => @record})) %>');
     action_link.target = $('#<%= row_selector %>');
     <%= render :partial => 'update_calculations', :formats => [:js] %>
-    <%= "ActiveScaffold.enable_form('#{form_selector}');" if params[:iframe] == 'true' %>
+    <% if params[:iframe] == 'true' %>
+      ActiveScaffold.enable_form('<%= form_selector %>');
+    <% end %>
   <% else %>
     <% if render_parent? %>
       <% if nested_singular_association? || render_parent_action == :row %>


### PR DESCRIPTION
1. Uses explicit comparison to 'true' (```if params[:dont_close] == 'true'```) to avoid case where parameter is 'false' but ```if params[:dont_close]``` is truthy. Also matches ```params[:iframe]``` tests elsewhere in file.
2. Fixes ```<%= "ActiveScaffold.enable_form('#{form_selector}');"...%>``` form which escapes the single quotes and doesn't work.