### PR TITLE
Make the TinyMCE bridge integrate better with the tinymce-rails gem

### DIFF
--- a/lib/active_scaffold/bridges/tiny_mce/helpers.rb
+++ b/lib/active_scaffold/bridges/tiny_mce/helpers.rb
@@ -12,10 +12,18 @@ class ActiveScaffold::Bridges::TinyMce
         base.alias_method_chain :onsubmit, :tiny_mce
       end
 
+      # The two column options that can be set specifically for the text_editor input
+      # is :tinymce, which overrides single values in the tinymce config.
+      # E.g. column[:foo].options[:tinymce] = {theme: 'other'} will change the theme
+      # but not the plugins, toolbars etc.
+      # The other one is :tinymce_config, which selects the config to use from tinymce.yml.
+      # See the tinymce-rails gem documentation for usage.
       def active_scaffold_input_text_editor(column, options)
         options[:class] = "#{options[:class]} mceEditor #{column.options[:class]}".strip
 
-        settings = {:theme => 'modern'}.merge(column.options[:tinymce] || {})
+        settings = tinymce_configuration(column.options[:tinymce_config] || :default).options.
+          reject{|k,v| k =='selector'}.
+          merge(column.options[:tinymce] || {})
         settings = settings.to_json
         settings = "tinyMCE.settings = #{settings};"
 

--- a/lib/active_scaffold/bridges/tiny_mce/helpers.rb
+++ b/lib/active_scaffold/bridges/tiny_mce/helpers.rb
@@ -42,6 +42,10 @@ class ActiveScaffold::Bridges::TinyMce
         end
         [onsubmit_without_tiny_mce, submit_js].compact.join ';'
       end
+
+      # The implementation is very tinymce specific, so it makes sense allowing :form_ui
+      # to be :tinymce as well
+      alias_method :active_scaffold_input_tinymce, :active_scaffold_input_text_editor
     end
 
     module SearchColumnHelpers

--- a/test/bridges/tiny_mce_test.rb
+++ b/test/bridges/tiny_mce_test.rb
@@ -45,7 +45,7 @@ class TinyMceTest < ActionView::TestCase
     expects(:request).returns(stub(:xhr? => true))
     config.columns[:name].options[:tinymce_config] = :alternate
 
-    assert_dom_equal %{<textarea name=\"record[name]\" class=\"name-input mceEditor\" id=\"record_name\">\n</textarea>\n<script#{' type="text/javascript"' if Rails::VERSION::MAJOR < 4}>\n//<![CDATA[\ntinyMCE.settings = {\"theme\":\"alternate\",\"toolbar\":\"undo redo | format\"};tinyMCE.execCommand('mceAddEditor', false, 'record_name');\n//]]>\n</script>}, active_scaffold_input_text_editor(config.columns[:name], :name => 'record[name]', :id => 'record_name', :class => 'name-input', :object => record)
+    assert_dom_equal %{<textarea name=\"record[name]\" class=\"name-input mceEditor\" id=\"record_name\">\n</textarea>\n<script#{' type="text/javascript"' if Rails::VERSION::MAJOR < 4}>\n//<![CDATA[\ntinyMCE.settings = {\"theme\":\"alternate\",\"toolbar\":\"undo redo | format\"};tinyMCE.execCommand('mceAddEditor', false, 'record_name');\n//]]>\n</script>}, active_scaffold_input_tinymce(config.columns[:name], :name => 'record[name]', :id => 'record_name', :class => 'name-input', :object => record)
   end
 
   protected

--- a/test/bridges/tiny_mce_test.rb
+++ b/test/bridges/tiny_mce_test.rb
@@ -4,6 +4,27 @@ class TinyMceTest < ActionView::TestCase
   include ActiveScaffold::Helpers::ViewHelpers
   include ActiveScaffold::Bridges::TinyMce::Helpers
 
+  # Mimic the behaviour of the tinymce-rails plugin function[1] to get
+  # configuration options from tinymce.yml
+  #
+  # [1]: https://github.com/spohlenz/tinymce-rails/blob/master/lib/tinymce/rails/helper.rb#L37
+  def tinymce_configuration(config=:default)
+    return case config
+           when :default
+             Class.new do
+               def options
+                 {theme: 'modern'}
+               end
+             end.new
+           when :alternate
+             Class.new do
+               def options
+                 {theme: 'alternate', toolbar: 'undo redo | format'}
+               end
+             end.new
+           end
+  end
+
   def test_includes
     ActiveScaffold::Bridges::TinyMce.expects(:install?).returns(true)
     ActiveScaffold.js_framework = :jquery
@@ -16,6 +37,15 @@ class TinyMceTest < ActionView::TestCase
     expects(:request).returns(stub(:xhr? => true))
 
     assert_dom_equal %{<textarea name=\"record[name]\" class=\"name-input mceEditor\" id=\"record_name\">\n</textarea>\n<script#{' type="text/javascript"' if Rails::VERSION::MAJOR < 4}>\n//<![CDATA[\ntinyMCE.settings = {\"theme\":\"modern\"};tinyMCE.execCommand('mceAddEditor', false, 'record_name');\n//]]>\n</script>}, active_scaffold_input_text_editor(config.columns[:name], :name => 'record[name]', :id => 'record_name', :class => 'name-input', :object => record)
+  end
+
+  def test_form_ui_alternate
+    config = ActiveScaffold::Config::Core.new(:company)
+    record = Company.new
+    expects(:request).returns(stub(:xhr? => true))
+    config.columns[:name].options[:tinymce_config] = :alternate
+
+    assert_dom_equal %{<textarea name=\"record[name]\" class=\"name-input mceEditor\" id=\"record_name\">\n</textarea>\n<script#{' type="text/javascript"' if Rails::VERSION::MAJOR < 4}>\n//<![CDATA[\ntinyMCE.settings = {\"theme\":\"alternate\",\"toolbar\":\"undo redo | format\"};tinyMCE.execCommand('mceAddEditor', false, 'record_name');\n//]]>\n</script>}, active_scaffold_input_text_editor(config.columns[:name], :name => 'record[name]', :id => 'record_name', :class => 'name-input', :object => record)
   end
 
   protected


### PR DESCRIPTION
Currently the bridge does not support the workflow outlined in [the readme of the tinymce-rails gem](https://github.com/spohlenz/tinymce-rails/blob/master/README.md). This patch will allow for the use of the tinymce.yml file and introduce a way to configure specific columns to use other configurations (:tinymce_configuration).

Also to reflect that the :text_editor form_ui option is very tinymce specific, allow form_ui to be :tinymce