### PR TITLE
Inclusion_validator_for_checkbox didn't pick up val options for rails 3

### DIFF
--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -426,7 +426,8 @@ module ActiveScaffold::DataStructures
     end
 
     def inclusion_validator_for_checkbox?(val)
-      @form_ui == :checkbox && [[true, false], [false, true]].include?(val.options[:with] || val.options[:within])
+      @form_ui == :checkbox &&
+        [[true, false], [false, true]].include?(val.options[:with] || val.options[:within] || val.options[:in])
     end
 
     def default_select_columns


### PR DESCRIPTION
In ActiveModel 3.2.22.2 the symbol used for possible values in the
InclusionValidator is :in. Add it and use it if none of the others are
found.