### PR TITLE
Bugfix select of existing record for nested subform.

### DIFF
--- a/lib/active_scaffold/actions/subform.rb
+++ b/lib/active_scaffold/actions/subform.rb
@@ -18,13 +18,18 @@ module ActiveScaffold::Actions
       @column = active_scaffold_config.columns[params[:child_association]]
 
       # NOTE: we don't check whether the user is allowed to update this record, because if not, we'll still let them associate the record. we'll just refuse to do more than associate, is all.
-      @record = @column.association.klass.find(params[:associated_id]) if params[:associated_id]
-      if @record
-        if (association = active_scaffold_config.columns[params[:child_association]].association.reverse)
-          if @record.class.reflect_on_association(association).collection?
-            @record.send(association) << @parent_record
-          else
-            @record.send("#{association}=", @parent_record)
+      if params[:associated_id]
+        @record = @column.association.klass.find(params[:associated_id])
+        if nested? # Generate a form that will update on save
+          # Store the associated_record in @parent_record, but avoid save - that is handled on form submit.
+          @parent_record.send("#{params[:child_association]}=", associated_record)
+        else # Edit the association directly.
+          if (association = active_scaffold_config.columns[params[:child_association]].association.reverse)
+            if @record.class.reflect_on_association(association).collection?
+              @record.send(association) << @parent_record
+            else
+              @record.send("#{association}=", @parent_record)
+            end
           end
         end
       else


### PR DESCRIPTION
When the subform is nested below another controller, then the
parent_record must be rendered, with the selected record in an
appropriate subform.
The previous code caused associations to be save on selection, instead
of rendering a form with an unsaved record.