### PR TITLE
Fix Rails 5 deprecation warning " Method to_a is deprecated"

### DIFF
--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -376,7 +376,7 @@ module ActiveScaffold
 
       def action_link_selected?(link, record)
         missing_options, url_options = replaced_action_link_url_options(link, record)
-        (url_options - params.to_a).blank? && missing_options.all? { |k, _| params[k].nil? }
+        (url_options - params.to_h.to_a).blank? && missing_options.all? { |k, _| params[k].nil? }
       end
 
       def action_link_html_options(link, record, options)


### PR DESCRIPTION
Original deprecation warning:

> DEPRECATION WARNING: Method to_a is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.0.1/classes/ActionController/Parameters.html (called from action_link_selected? at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-ab6218d9ad5d/lib/active_scaffold/helpers/view_helpers.rb:379)