### PR TITLE
Fix Rails 5 deprecation warnings: stop using alias_method_chain, use Module#prepend instead

### DIFF
--- a/lib/active_scaffold/extensions/action_controller_rendering.rb
+++ b/lib/active_scaffold/extensions/action_controller_rendering.rb
@@ -1,7 +1,7 @@
 # wrap the action rendering for ActiveScaffold controllers
 module ActionController #:nodoc:
-  class Base
-    def render_with_active_scaffold(*args, &block)
+  module WithActiveScaffold
+    def render(*args, &block)
       if self.class.uses_active_scaffold? && params[:adapter] && @rendering_adapter.nil? && request.xhr?
         @rendering_adapter = true # recursion control
         # if we need an adapter, then we render the actual stuff to a string and insert it into the adapter template
@@ -11,9 +11,12 @@ module ActionController #:nodoc:
                :use_full_path => true, :layout => false, :content_type => :html
         @rendering_adapter = nil # recursion control
       else
-        render_without_active_scaffold(*args, &block)
+        super(*args, &block)
       end
     end
-    alias_method_chain :render, :active_scaffold
+  end
+
+  class Base
+    prepend WithActiveScaffold
   end
 end

--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -2,16 +2,20 @@ module ActionView
   class LookupContext
     attr_accessor :last_template
 
-    def find_template_with_last_template(name, prefixes = [], partial = false, keys = [], options = {})
-      self.last_template = find_template_without_last_template(name, prefixes, partial, keys, options)
+    module WithLastTemplate
+      def find_template(name, prefixes = [], partial = false, keys = [], options = {})
+        self.last_template = super(name, prefixes, partial, keys, options)
+      end
     end
-    alias_method_chain :find_template, :last_template
+
+    prepend WithLastTemplate
   end
 end
 
 # wrap the action rendering for ActiveScaffold views
 module ActionView::Helpers #:nodoc:
   module RenderingHelper
+
     #
     # Adds two rendering options.
     #
@@ -34,95 +38,98 @@ module ActionView::Helpers #:nodoc:
     #
     # Defining options[:label] lets you completely customize the list title for the embedded scaffold.
     #
-    def render_with_active_scaffold(*args, &block)
-      if args.first.is_a?(Hash) && args.first[:active_scaffold]
-        require 'digest/sha2'
-        options = args.first
+    module WithActiveScaffold
+      def render(*args, &block)
+        if args.first.is_a?(Hash) && args.first[:active_scaffold]
+          require 'digest/sha2'
+          options = args.first
 
-        remote_controller = options[:active_scaffold]
-        constraints = options[:constraints]
-        conditions = options[:conditions]
-        eid = Digest::SHA512.hexdigest(params[:controller] + remote_controller.to_s + constraints.to_s + conditions.to_s)
-        eid_info = session["as:#{eid}"] ||= {}
-        if constraints
-          eid_info['constraints'] = constraints
-        else
-          eid_info.delete 'constraints'
-        end
-        if conditions
-          eid_info['conditions'] = conditions
-        else
-          eid_info.delete 'conditions'
-        end
-        if options[:label]
-          eid_info['list'] = {'label' => options[:label]}
-        else
-          eid_info.delete 'list'
-        end
-        session.delete "as:#{eid}" if eid_info.empty?
-        options[:params] ||= {}
-        options[:params].merge! :eid => eid, :embedded => true
+          remote_controller = options[:active_scaffold]
+          constraints = options[:constraints]
+          conditions = options[:conditions]
+          eid = Digest::SHA512.hexdigest(params[:controller] + remote_controller.to_s + constraints.to_s + conditions.to_s)
+          eid_info = session["as:#{eid}"] ||= {}
+          if constraints
+            eid_info['constraints'] = constraints
+          else
+            eid_info.delete 'constraints'
+          end
+          if conditions
+            eid_info['conditions'] = conditions
+          else
+            eid_info.delete 'conditions'
+          end
+          if options[:label]
+            eid_info['list'] = {'label' => options[:label]}
+          else
+            eid_info.delete 'list'
+          end
+          session.delete "as:#{eid}" if eid_info.empty?
+          options[:params] ||= {}
+          options[:params].merge! :eid => eid, :embedded => true
 
-        id = "as_#{eid}-embedded"
-        url_options = {:controller => remote_controller.to_s, :action => 'index'}.merge(options[:params])
+          id = "as_#{eid}-embedded"
+          url_options = {:controller => remote_controller.to_s, :action => 'index'}.merge(options[:params])
 
-        if controller.respond_to?(:render_component_into_view, true)
-          controller.send(:render_component_into_view, url_options)
-        else
-          url = url_for(url_options)
-          content_tag(:div, :id => id, :class => 'active-scaffold-component', :data => {:refresh => url}) do
-            # parse the ActiveRecord model name from the controller path, which
-            # might be a namespaced controller (e.g., 'admin/admins')
-            model = remote_controller.to_s.sub(/.*\//, '').singularize
-            content_tag(:div, :class => 'active-scaffold-header') do
-              content_tag :h2, link_to(args.first[:label] || active_scaffold_config_for(model).list.label, url, :remote => true, :class => 'load-embedded')
+          if controller.respond_to?(:render_component_into_view, true)
+            controller.send(:render_component_into_view, url_options)
+          else
+            url = url_for(url_options)
+            content_tag(:div, :id => id, :class => 'active-scaffold-component', :data => {:refresh => url}) do
+              # parse the ActiveRecord model name from the controller path, which
+              # might be a namespaced controller (e.g., 'admin/admins')
+              model = remote_controller.to_s.sub(/.*\//, '').singularize
+              content_tag(:div, :class => 'active-scaffold-header') do
+                content_tag :h2, link_to(args.first[:label] || active_scaffold_config_for(model).list.label, url, :remote => true, :class => 'load-embedded')
+              end
             end
           end
-        end
 
-      elsif args.first == :super
-        @_view_paths ||= lookup_context.view_paths.clone
-        @_last_template ||= lookup_context.last_template
-        parts = @virtual_path.split('/')
-        template = parts.pop
-        prefix = parts.join('/')
+        elsif args.first == :super
+          @_view_paths ||= lookup_context.view_paths.clone
+          @_last_template ||= lookup_context.last_template
+          parts = @virtual_path.split('/')
+          template = parts.pop
+          prefix = parts.join('/')
 
-        options = args[1] || {}
-        options[:locals] ||= {}
-        if view_stack.last
-          options[:locals] = view_stack.last[:locals].merge!(options[:locals]) if view_stack.last[:locals]
-          options[:object] ||= view_stack.last[:object] if view_stack.last[:object]
-        end
-        options[:template] = template
-        # if prefix is active_scaffold_overrides we must try to render with this prefix in following paths
-        if prefix != 'active_scaffold_overrides'
-          options[:prefixes] = lookup_context.prefixes.drop((lookup_context.prefixes.find_index(prefix) || -1) + 1)
+          options = args[1] || {}
+          options[:locals] ||= {}
+          if view_stack.last
+            options[:locals] = view_stack.last[:locals].merge!(options[:locals]) if view_stack.last[:locals]
+            options[:object] ||= view_stack.last[:object] if view_stack.last[:object]
+          end
+          options[:template] = template
+          # if prefix is active_scaffold_overrides we must try to render with this prefix in following paths
+          if prefix != 'active_scaffold_overrides'
+            options[:prefixes] = lookup_context.prefixes.drop((lookup_context.prefixes.find_index(prefix) || -1) + 1)
+          else
+            options[:prefixes] = ['active_scaffold_overrides']
+            last_view_path = File.expand_path(File.dirname(File.dirname(lookup_context.last_template.inspect)), Rails.root)
+            lookup_context.view_paths = view_paths.drop(view_paths.find_index { |path| path.to_s == last_view_path } + 1)
+          end
+          result = super options
+          lookup_context.view_paths = @_view_paths if @_view_paths
+          lookup_context.last_template = @_last_template if @_last_template
+          result
         else
-          options[:prefixes] = ['active_scaffold_overrides']
-          last_view_path = File.expand_path(File.dirname(File.dirname(lookup_context.last_template.inspect)), Rails.root)
-          lookup_context.view_paths = view_paths.drop(view_paths.find_index { |path| path.to_s == last_view_path } + 1)
+          @_view_paths ||= lookup_context.view_paths.clone
+          last_template = lookup_context.last_template
+          current_view = if args[0].is_a?(Hash)
+                           {:locals => args[0][:locals], :object => args[0][:object]}
+                         else # call is render 'partial', locals_hash
+                           {:locals => args[1]}
+                         end
+          view_stack << current_view if current_view
+          lookup_context.view_paths = @_view_paths # reset view_paths in case a view render :super, and then render :partial
+          result = super(*args, &block)
+          view_stack.pop if current_view.present?
+          lookup_context.last_template = last_template
+          result
         end
-        result = render_without_active_scaffold options
-        lookup_context.view_paths = @_view_paths if @_view_paths
-        lookup_context.last_template = @_last_template if @_last_template
-        result
-      else
-        @_view_paths ||= lookup_context.view_paths.clone
-        last_template = lookup_context.last_template
-        current_view = if args[0].is_a?(Hash)
-                         {:locals => args[0][:locals], :object => args[0][:object]}
-                       else # call is render 'partial', locals_hash
-                         {:locals => args[1]}
-                       end
-        view_stack << current_view if current_view
-        lookup_context.view_paths = @_view_paths # reset view_paths in case a view render :super, and then render :partial
-        result = render_without_active_scaffold(*args, &block)
-        view_stack.pop if current_view.present?
-        lookup_context.last_template = last_template
-        result
       end
     end
-    alias_method_chain :render, :active_scaffold
+
+    prepend WithActiveScaffold
 
     def view_stack
       @_view_stack ||= []

--- a/lib/active_scaffold/extensions/name_option_for_datetime.rb
+++ b/lib/active_scaffold/extensions/name_option_for_datetime.rb
@@ -1,15 +1,14 @@
 module ActiveScaffold
-  module DateSelectExtension
-    def datetime_selector_with_name(options, html_options)
+  module WithName
+    def datetime_selector(options, html_options)
       options[:prefix] = options[:name].gsub(/\[[^\[]*\]$/, '') if options[:name]
-      datetime_selector_without_name(options, html_options)
+      super(options, html_options)
     end
+  end
 
+  module DateSelectExtension
     def self.included(base)
-      base.class_eval do
-        alias_method_chain :datetime_selector, :name
-        private :datetime_selector_without_name, :datetime_selector_with_name, :datetime_selector
-      end
+      base.prepend WithName
     end
   end
 end

--- a/lib/active_scaffold/extensions/paginator_extensions.rb
+++ b/lib/active_scaffold/extensions/paginator_extensions.rb
@@ -1,11 +1,14 @@
 require 'active_scaffold/paginator'
 
 Paginator.class_eval do
-  # Total number of pages
-  def number_of_pages_with_infinite
-    number_of_pages_without_infinite if @count
+  module WithInfinite
+    def number_of_pages
+      super if @count
+    end
   end
-  alias_method_chain :number_of_pages, :infinite
+
+  # Total number of pages
+  prepend WithInfinite
 
   # Is this an "infinite" paginator
   def infinite?
@@ -18,12 +21,15 @@ Paginator.class_eval do
 end
 
 Paginator::Page.class_eval do
-  # Checks to see if there's a page after this one
-  def next_with_infinite?
-    return true if @pager.infinite?
-    next_without_infinite?
+  module WithInfinite
+    def next?
+      return true if @pager.infinite?
+      super
+    end
   end
-  alias_method_chain :next?, :infinite
+
+  # Checks to see if there's a page after this one
+  prepend WithInfinite
 
   def empty?
     if @pager.infinite?

--- a/lib/active_scaffold/extensions/reverse_associations.rb
+++ b/lib/active_scaffold/extensions/reverse_associations.rb
@@ -1,13 +1,15 @@
 module ActiveScaffold
   module ReverseAssociation
+    module WithAutodetect
+      def inverse_of
+        super || autodetect_inverse
+      end
+    end
+
     module CommonMethods
       def self.included(base)
         base.class_eval { attr_writer :reverse }
-        base.alias_method_chain :inverse_of, :autodetect
-      end
-
-      def inverse_of_with_autodetect
-        inverse_of_without_autodetect || autodetect_inverse
+        base.prepend(WithAutodetect)
       end
 
       def inverse_for?(klass)

--- a/lib/active_scaffold/tableless.rb
+++ b/lib/active_scaffold/tableless.rb
@@ -54,15 +54,28 @@ class ActiveScaffold::Tableless < ActiveRecord::Base
     end
   end
 
-  module Association
-    def self.included(base)
-      base.alias_method_chain :association_scope, :tableless
-      base.alias_method_chain :target_scope, :tableless
+  module Tableless
+    def association_scope
+      @association_scope ||= overrided_association_scope if klass < ActiveScaffold::Tableless
+      super
     end
 
-    def association_scope_with_tableless
-      @association_scope ||= overrided_association_scope if klass < ActiveScaffold::Tableless
-      association_scope_without_tableless
+    def target_scope
+      super.tap do |scope|
+        if klass < ActiveScaffold::Tableless
+          class << scope; include RelationExtension; end
+        end
+      end
+    end
+
+    def get_records
+      klass < ActiveScaffold::Tableless ? scope.to_a : super
+    end
+  end
+
+  module Association
+    def self.included(base)
+      base.prepend(Tableless)
     end
 
     def overrided_association_scope
@@ -72,33 +85,23 @@ class ActiveScaffold::Tableless < ActiveRecord::Base
         AssociationScope.new(self).scope
       end
     end
-
-    def target_scope_with_tableless
-      target_scope_without_tableless.tap do |scope|
-        if klass < ActiveScaffold::Tableless
-          class << scope; include RelationExtension; end
-        end
-      end
-    end
   end
 
   module CollectionAssociation
     def self.included(base)
-      base.alias_method_chain :get_records, :tableless if Rails.version >= '4.2'
+      base.prepend(Tableless) if Rails.version >= '4.2'
     end
+  end
 
-    def get_records_with_tableless
-      klass < ActiveScaffold::Tableless ? scope.to_a : get_records_without_tableless
+  module TablelessSingularAssociation
+    def get_records
+      klass < ActiveScaffold::Tableless ? scope.limit(1).to_a : super
     end
   end
 
   module SingularAssociation
     def self.included(base)
-      base.alias_method_chain :get_records, :tableless if Rails.version >= '4.2'
-    end
-
-    def get_records_with_tableless
-      klass < ActiveScaffold::Tableless ? scope.limit(1).to_a : get_records_without_tableless
+      base.prepend(TablelessSingularAssociation)
     end
   end
 


### PR DESCRIPTION
Fix the following warnings:

> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <class:Base> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/action_controller_rendering.rb:17)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <class:LookupContext> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/action_view_rendering.rb:8)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <module:RenderingHelper> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/action_view_rendering.rb:125)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/name_option_for_datetime.rb:10)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in <top (required)> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/paginator_extensions.rb:8)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in <top (required)> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/paginator_extensions.rb:26)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/reverse_associations.rb:6)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/reverse_associations.rb:6)
> /Users/david/.rvm/rubies/ruby-2.3.0/bin/ruby -I/Users/david/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.5.2/lib:/Users/david/.rvm/gems/ruby-2.3.0/gems/rspec-support-3.5.0/lib /Users/david/.rvm/gems/ruby-2.3.0/gems/rspec-core-3.5.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <class:Base> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/action_controller_rendering.rb:17)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <class:LookupContext> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/action_view_rendering.rb:8)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <module:RenderingHelper> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/action_view_rendering.rb:125)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/name_option_for_datetime.rb:10)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in <top (required)> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/paginator_extensions.rb:8)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in <top (required)> at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/paginator_extensions.rb:26)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/reverse_associations.rb:6)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/extensions/reverse_associations.rb:6)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/tableless.rb:59)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/tableless.rb:60)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/tableless.rb:87)
> DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from included at /Users/david/.rvm/gems/ruby-2.3.0/bundler/gems/active_scaffold-aeec08d631e6/lib/active_scaffold/tableless.rb:97)
> 
> 