### PR TITLE
Fix jQuery-ui 6.0 (rails 4.2.7)

### DIFF
--- a/app/assets/javascripts/active_scaffold.js.erb
+++ b/app/assets/javascripts/active_scaffold.js.erb
@@ -7,12 +7,13 @@
       require_asset "jquery-ui"
     elsif Jquery.const_defined? 'Ui'
       jquery_ui_prefix = Jquery::Ui::Rails::VERSION < '5.0.0' ? 'jquery.ui.' : 'jquery-ui/'
+      jquery_ui_widgets_prefix = Jquery::Ui::Rails::VERSION >= '6.0.0' ? '/widgets/' : ''
       require_asset "#{jquery_ui_prefix}core"
       require_asset "#{jquery_ui_prefix}effect"
-      require_asset "#{jquery_ui_prefix}sortable"
-      require_asset "#{jquery_ui_prefix}draggable"
-      require_asset "#{jquery_ui_prefix}droppable"
-      require_asset "#{jquery_ui_prefix}datepicker"
+      require_asset "#{jquery_ui_prefix}#{jquery_ui_widgets_prefix}sortable"
+      require_asset "#{jquery_ui_prefix}#{jquery_ui_widgets_prefix}draggable"
+      require_asset "#{jquery_ui_prefix}#{jquery_ui_widgets_prefix}droppable"
+      require_asset "#{jquery_ui_prefix}#{jquery_ui_widgets_prefix}datepicker"
     else
       jquery_ui = false
     end


### PR DESCRIPTION
jQuery-ui 6 changes: sortable, draggable, droppable and datepicker have
been moved to widgets directory.