### PR TITLE
Allows data-loading to be optionally set on the base form

### DIFF
--- a/app/views/active_scaffold_overrides/_base_form.html.erb
+++ b/app/views/active_scaffold_overrides/_base_form.html.erb
@@ -25,7 +25,7 @@ options = {:onsubmit => onsubmit,
            :multipart => multipart,
            :class => "as_form #{form_action.to_s}",
            :method => method,
-           'data-loading' => true}
+           'data-loading' => defined? loading ? loading : true}
 cancel_options = {:class => 'as_cancel'}
 
 cancel_options[:remote] = true if xhr #cancel link does nt have to care about multipart forms


### PR DESCRIPTION
This is useful in some of the active_scaffold_export forks to be able to disable the loading indicator, which does not work correctly for export.