### PR TITLE
Revert commit SHA: 5e2bcef8232f0f9dba0bfc7c09786f5ad34ed2af to fix

### DIFF
--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -35,13 +35,18 @@ module ActiveScaffold #:nodoc:
     #
     def render(*args, &block)
       if args.first.is_a?(Hash) && args.first[:active_scaffold]
-        require 'digest/sha2'
+        require 'digest/md5'
         options = args.first
 
         remote_controller = options[:active_scaffold]
         constraints = options[:constraints]
         conditions = options[:conditions]
-        eid = Digest::SHA512.hexdigest(params[:controller] + remote_controller.to_s + constraints.to_s + conditions.to_s)
+        # It is important that the EID hash remains short as to not contribute
+        # to a large session size and thus a possible cookie overflow exception
+        # when using rails CookieStore or EncryptedCookieStore. For example,
+        # when rendering many embedded scaffolds with constraints or conditions
+        # on a single page.
+        eid = Digest::MD5.hexdigest(params[:controller] + remote_controller.to_s + constraints.to_s + conditions.to_s)
         eid_info = session["as:#{eid}"] ||= {}
         if constraints
           eid_info['constraints'] = constraints


### PR DESCRIPTION
issue where the EID hash length can overflow the session cookie
store when rendering many embedded scaffolds with conditions at a
time. Fixes issue #536. The long-term fix should be to replace the
use of the session with something else for :conditions and :constraints.