### PR TITLE
Fix an error in AS master branch in field_search because a change in Rails 5.0.1 ActiveRecord column type.

### DIFF
--- a/lib/active_scaffold/core.rb
+++ b/lib/active_scaffold/core.rb
@@ -232,6 +232,8 @@ module ActiveScaffold
         column.type_cast value
       elsif Rails.version < '5.0'
         column.type_cast_from_user value
+      elsif Rails.version >= '5.0.1'
+        column.type.cast value
       else
         cast_type = ActiveRecord::Type.lookup column.type
         cast_type ? cast_type.cast(value) : value


### PR DESCRIPTION
…Rails 5.0.1 ActiveRecord column type.

Column type in ActiveRecord now show:
Model.columns[1].type:
=> #<ActiveModel::Type::String:0x36af922d @precision=nil, @limit=3, @scale=nil>
and before was:
=> :string