### PR TITLE
Fix an error in AS master branch in field_search because a change in Rails 5.0.1 ActiveRecord column type.

### DIFF
--- a/lib/active_scaffold/finder.rb
+++ b/lib/active_scaffold/finder.rb
@@ -96,7 +96,12 @@ module ActiveScaffold
           return send("condition_for_#{column.name}_column", column, value, like_pattern)
         end
         return unless column && column.search_sql && !value.blank?
-        search_ui = column.search_ui || column.column.try(:type)
+        search_ui = nil
+        if Rails.version < '5.0'
+          search_ui = column.search_ui || column.column.try(:type)
+        else
+          search_ui = column.search_ui || column.column.type.type
+        end
         begin
           sql, *values =
             if search_ui && respond_to?("condition_for_#{search_ui}_type")


### PR DESCRIPTION
…Rails 5.0.1 ActiveRecord column type.

Column type in ActiveRecord now show:
Model.columns[1].type:
=> #<ActiveModel::Type::String:0x36af922d @precision=nil, @limit=3, @scale=nil>
and before was:
=> :string