### PR TITLE
Fix an error in AS master branch in field_search because a change in Rails 5.0.1 ActiveRecord column type.

### DIFF
--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -313,7 +313,12 @@ module ActiveScaffold::DataStructures
       @actions_for_association_links = self.class.actions_for_association_links.clone if self.association
       @select_columns = default_select_columns
 
-      @text = @column.nil? || [:string, :text, String].include?(@column.type)
+      @text = false
+      if Rails.version >= '5.0.1'
+        @text = @column.nil? || [:string, :text, String].include?(@column.type.type)
+      else
+        @text = @column.nil? || [:string, :text, String].include?(@column.type)
+      end
       @number = false
       if @column
         if active_record_class.respond_to?(:defined_enums) && active_record_class.defined_enums[name.to_s]


### PR DESCRIPTION
…Rails 5.0.1 ActiveRecord column type.

Column type in ActiveRecord now show:
Model.columns[1].type:
=> #<ActiveModel::Type::String:0x36af922d @precision=nil, @limit=3, @scale=nil>
and before was:
=> :string