### PR TITLE
3 4 stable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- Fix for using jquery-ui-rails 6.0
+
 = 3.4.42
 - Fix for protected and private authorized methods
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    rubocop (0.46.0)
+    rubocop (0.45.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)

--- a/app/assets/javascripts/active_scaffold.js.erb
+++ b/app/assets/javascripts/active_scaffold.js.erb
@@ -7,14 +7,14 @@
       require_asset "jquery-ui"
     elsif Jquery.const_defined? 'Ui'
       jquery_ui_prefix = Jquery::Ui::Rails::VERSION < '5.0.0' ? 'jquery.ui.' : 'jquery-ui/'
-      jquery_widget_prefix = (Jquery::Ui::Rails::VERSION > '6' ? "widgets" : "")
-
+      jquery_ui_widgets_prefix = Jquery::Ui::Rails::VERSION >= '6.0.0' ? '/widgets/' : ''
       require_asset "#{jquery_ui_prefix}core"
       require_asset "#{jquery_ui_prefix}effect"
-      require_asset "#{jquery_ui_prefix}#{jquery_widget_prefix}/sortable"
-      require_asset "#{jquery_ui_prefix}#{jquery_widget_prefix}/draggable"
-      require_asset "#{jquery_ui_prefix}#{jquery_widget_prefix}/droppable"
-      require_asset "#{jquery_ui_prefix}#{jquery_widget_prefix}/datepicker"
+      require_asset "#{jquery_ui_prefix}effects/effect-highlight" if Jquery::Ui::Rails::VERSION >= '6.0.0'
+      require_asset "#{jquery_ui_prefix}#{jquery_ui_widgets_prefix}sortable"
+      require_asset "#{jquery_ui_prefix}#{jquery_ui_widgets_prefix}draggable"
+      require_asset "#{jquery_ui_prefix}#{jquery_ui_widgets_prefix}droppable"
+      require_asset "#{jquery_ui_prefix}#{jquery_ui_widgets_prefix}datepicker"
     else
       jquery_ui = false
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,4 @@
-if RUBY_ENGINE == 'ruby'
-  require 'simplecov'
-  SimpleCov.start { add_filter 'test' }
-end
+require 'simplecov' unless RUBY_ENGINE == 'rbx'
 
 ENV['RAILS_ENV'] = 'test'
 require 'mock_app/config/environment'
@@ -11,9 +8,6 @@ require 'mocha/setup'
 
 require 'minitest/reporters'
 Minitest::Reporters.use!
-
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
 
 def load_schema
   stdout = $stdout


### PR DESCRIPTION
Muy estimado Sergio, por favor corregir las versiones anteriores a la 3.4.31 en la línea 70 del archivo:
lib/active_scaffold/extensions/reverse_associations.rb,
ya que presentan este código que no tiene mucho sentido:
if assoc.foreign_key.is_a? Array
                next unless assoc.foreign_key.to_sym == foreign_key.to_sym
              else
                next unless assoc.foreign_key.to_sym == foreign_key.to_sym
end
y debe ser este:
if assoc.foreign_key.is_a? Array
                next unless assoc.foreign_key == foreign_key
              else
                next unless assoc.foreign_key.to_sym == foreign_key.to_sym
end
A partir de la versión 3.4.31 si veo que está correcto.
Te agradezco de antemano tu inmenso esfuerzo en darle soporte a este software que lo adoro, por cierto.. Eres una gran persona y si todos fueramos como tú, este mundo no estaría en crisis, sino que sería el mejor vividero del universo.
Saludos.