### PR TITLE
Fix for undefined method 'search_params'

### DIFF
--- a/lib/active_scaffold/helpers/list_column_helpers.rb
+++ b/lib/active_scaffold/helpers/list_column_helpers.rb
@@ -375,7 +375,7 @@ module ActiveScaffold
           url_options[:id] = nil if @remove_id_from_list_links
           url_options = params_for(url_options)
           unless active_scaffold_config.store_user_settings
-            url_options[:search] = search_params if search_params.present?
+            url_options[:search] = search_params if respond_to?(:search_params) && search_params.present?
           end
           link_to column_heading_label(column), url_options, options
         else

--- a/lib/active_scaffold/helpers/pagination_helpers.rb
+++ b/lib/active_scaffold/helpers/pagination_helpers.rb
@@ -13,7 +13,7 @@ module ActiveScaffold
           url_options = params_for(url_options)
         end
         unless active_scaffold_config.store_user_settings
-          url_options[:search] = search_params if search_params.present?
+          url_options[:search] = search_params if respond_to?(:search_params) && search_params.present?
           if active_scaffold_config.list.user.user_sorting?
             column, direction = active_scaffold_config.list.user.sorting.first
             url_options[:sort] = column.name


### PR DESCRIPTION

In controllers with the `:search` action disabled AND `config.store_user_settings = false` AND `clear_helpers` I would receive this error:

```
An ActionView::Template::Error occurred in consultations#index:

  undefined local variable or method `search_params' for #<#<Class:0x00000008a03ae0>:0x0000000cdb1e18>
```

After some debugging, it appears that there is a missing `respond_to?` check in some of the other included helpers.  This PR adds them and resolves the issue