### PR TITLE
Add :in to the list of values checked for booleans in inclusion_validator_for_checkbox?(val)

### DIFF
--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -432,7 +432,7 @@ module ActiveScaffold::DataStructures
 
     def inclusion_validator_for_checkbox?(val)
       @form_ui == :checkbox &&
-        [[true, false], [false, true]].include?(val.options[:with] || val.options[:within])
+        [[true, false], [false, true]].include?(val.options[:with] || val.options[:within] || val.options[:in])
     end
 
     def default_select_columns


### PR DESCRIPTION
The flag :within is no longer there for InclusionValidator for
booleans in latest Rails 4.2, and the function description for
validates_inclusion_of()[[1]] states that :within is an alias for :in,
so using that if it exists should ammount for the same.

[1]: https://github.com/rails/rails/blob/20c91119903f70eb19aed33fe78417789dbf070f/activemodel/lib/active_model/validations/inclusion.rb