### PR TITLE
Checks if sort column is available in the list config

### DIFF
--- a/lib/active_scaffold/config/list.rb
+++ b/lib/active_scaffold/config/list.rb
@@ -270,7 +270,7 @@ module ActiveScaffold::Config
           self['sort'] = [@params['sort'], @params['sort_direction']] if @params['sort'] && @params['sort_direction']
           self['sort'] = nil if @params['sort_direction'] == 'reset'
 
-          if self['sort'] && @conf.core.columns[self['sort'][0]]
+          if self['sort'] && @conf.columns.include?(self['sort'][0])
             sorting = @conf.sorting.clone
             sorting.set(*self['sort'])
             @sorting = sorting


### PR DESCRIPTION
The missing column check is against all columns, however if the column exists in the core config, but is not in the list config, there is the potential for a column from a table that is not included to end up in the ORDER BY clause.

For example, if the sort column is from an association table, but that column is not included in the list config columns, the column will be added to the ORDER BY, but the table will not be in the FROM clause.

This situation could happen if a user bookmarks a URL with params for sorting on a column from an association, but later that column is removed from the list config columns and the user visits that URL, causing an error.