### PR TITLE
Allow setting of 'false' value for date_picker options

### DIFF
--- a/app/assets/javascripts/jquery/date_picker_bridge.js.erb
+++ b/app/assets/javascripts/jquery/date_picker_bridge.js.erb
@@ -7,7 +7,7 @@ jQuery.extend(Object.getPrototypeOf(jQuery.datepicker), {
     for (var attrName in this._defaults) {
       if(this._defaults.hasOwnProperty(attrName)){
         var attrValue = $target.data(attrName.toLowerCase());
-        if (attrValue) {
+        if (attrValue !== undefined) {
           try {
             inlineSettings[attrName] = eval(attrValue);
           } catch (err) {


### PR DESCRIPTION
Setting options on the date_picker plugin with a value of `false` fails due to a naive comparison in this conditional.  I believe comparing to `undefined` is correct, and resolves this issue.