### PR TITLE
Fixes sorting on column that is not included for SQL Server

### DIFF
--- a/lib/active_scaffold/engine.rb
+++ b/lib/active_scaffold/engine.rb
@@ -30,6 +30,9 @@ module ActiveScaffold
           if defined?(PostgreSQLAdapter)
             PostgreSQLAdapter.send :include, ActiveScaffold::ConnectionAdapters::PostgreSQLAdapter
           end
+          if defined?(SQLServerAdapter)
+            SQLServerAdapter.send :include, ActiveScaffold::ConnectionAdapters::SQLServerAdapter
+          end
         end
       end
     end

--- a/lib/active_scaffold/extensions/connection_adapter.rb
+++ b/lib/active_scaffold/extensions/connection_adapter.rb
@@ -11,5 +11,11 @@ module ActiveScaffold
         true
       end
     end
+
+    module SQLServerAdapter
+      def needs_order_expressions_in_select?
+        true
+      end
+    end
   end
 end


### PR DESCRIPTION
I believe SQL Server needs the same special handling that was added for PostgreSQL in #502.

For SQL Server, if the list is being sorted by a column that is not displayed in the list, you end up with an error like this:
`
TinyTds::Error: ORDER BY items must appear in the select list if SELECT DISTINCT is specified.: EXEC sp_executesql N'SELECT  DISTINCT [patient_logs].* FROM [patient_logs] LEFT OUTER JOIN [tag_tracks] ON [tag_tracks].[id] = [patient_logs].[tag_id] LEFT OUTER JOIN [areas] ON [areas].[id] = [tag_tracks].[area_id]  ORDER BY areas.title DESC OFFSET 0 ROWS FETCH NEXT 25 ROWS ONLY'
`

If `needs_order_expressions_in_select?` returns `true`, the query works as expected.