### PR TITLE
Rails 5.2 ActiveModel no longer contains the :text type.  That type w…

### DIFF
--- a/lib/active_scaffold/attribute_params.rb
+++ b/lib/active_scaffold/attribute_params.rb
@@ -323,7 +323,7 @@ module ActiveScaffold
           column.type_cast_from_database(column.default)
         else
           column_type = ActiveScaffold::OrmChecks.column_type(klass, column_name)
-          cast_type = ActiveModel::Type.lookup column_type
+          cast_type = ActiveRecord::Type.lookup column_type
           cast_type ? cast_type.deserialize(column.default) : column.default
         end
       end

--- a/lib/active_scaffold/core.rb
+++ b/lib/active_scaffold/core.rb
@@ -237,7 +237,7 @@ module ActiveScaffold
       elsif column.type.respond_to? :cast # jruby-jdbc and rails 5
         column.type.cast value
       else
-        cast_type = ActiveModel::Type.lookup column.type
+        cast_type = ActiveRecord::Type.lookup column.type
         cast_type ? cast_type.cast(value) : value
       end
     end


### PR DESCRIPTION
…as moved to ActiveRecord.