### PR TITLE
Slight refactor to custom render method

### DIFF
--- a/lib/active_scaffold/extensions/action_controller_rendering.rb
+++ b/lib/active_scaffold/extensions/action_controller_rendering.rb
@@ -5,7 +5,13 @@ module ActiveScaffold
       if self.class.uses_active_scaffold? && params[:adapter] && @rendering_adapter.nil? && request.xhr?
         @rendering_adapter = true # recursion control
         # if we need an adapter, then we render the actual stuff to a string and insert it into the adapter template
-        opts = args.blank? ? {} : args.first
+
+        # NOTE this line fails when integrating with wicked_pdf.  An array with a nil value is passed in and thus fails in the render
+        # opts = args.blank? ? {} : args.first
+
+        # NOTE replaced with this line which will take into account nil entries in array
+        opts = args.any? ? args.first : {}
+
         render :partial => params[:adapter][1..-1],
                :locals => {:payload => render_to_string(opts.merge(:layout => false), &block).html_safe},
                :use_full_path => true, :layout => false, :content_type => :html

--- a/lib/active_scaffold/extensions/action_controller_rendering.rb
+++ b/lib/active_scaffold/extensions/action_controller_rendering.rb
@@ -5,11 +5,6 @@ module ActiveScaffold
       if self.class.uses_active_scaffold? && params[:adapter] && @rendering_adapter.nil? && request.xhr?
         @rendering_adapter = true # recursion control
         # if we need an adapter, then we render the actual stuff to a string and insert it into the adapter template
-
-        # NOTE this line fails when integrating with wicked_pdf.  An array with a nil value is passed in and thus fails in the render
-        # opts = args.blank? ? {} : args.first
-
-        # NOTE replaced with this line which will take into account nil entries in array
         opts = args.any? ? args.first : {}
 
         render :partial => params[:adapter][1..-1],


### PR DESCRIPTION
When I added wicked_pdf to my Rails app that includes active_scaffold.  I ended up getting an error when rendering because wicked_pdf also has a custom render method which gets called before the ActiveScaffold one.  In this scenario the args was an array with a single nil item.  The original code was checking for args.blank? which in this case returned false.   So later when opts.merge was executed it errored out because opts is nil.  So I replaced args.blank? with args.any? and now since args is just an array with a nil entry it returns false and opts gets correctly initialized to an empty hash and all is good.  Since we are expecting args to be an array it seems better to check for elements with any? than with blank? 