### PR TITLE
Attributes (parameters) fix

### DIFF
--- a/lib/active_scaffold/attribute_params.rb
+++ b/lib/active_scaffold/attribute_params.rb
@@ -72,7 +72,7 @@ module ActiveScaffold
     end
 
     def multi_parameter_attributes(attributes)
-      attributes.each_with_object({}) do |(k, v), result|
+      params_hash(attributes).each_with_object({}) do |(k, v), result|
         next unless k.include? '('
         column_name = k.split('(').first
         result[column_name] ||= []

--- a/lib/active_scaffold/bridges/usa_state_select/usa_state_select_helper.rb
+++ b/lib/active_scaffold/bridges/usa_state_select/usa_state_select_helper.rb
@@ -52,8 +52,7 @@ module ActiveScaffold::Bridges
       def to_usa_state_select_tag(priority_states, options, html_options)
         html_options = html_options.stringify_keys
         add_default_name_and_id(html_options)
-        value = value(object)
-        selected_value = options.key?(:selected) ? options[:selected] : value
+        selected_value = options.key?(:selected) ? options[:selected] : (method(:value).parameters.any? ? value(object) : value)
         content_tag('select', add_options(usa_state_options_for_select(selected_value, priority_states), options, selected_value), html_options)
       end
     end


### PR DESCRIPTION
The multi_parameter_attributes method now uses the params_hash method from actions core to make sure it has a hash and not an ActionController::Parameters object.