### PR TITLE
allow 3.5 stable to run on rails 5.2.3

### DIFF
--- a/active_scaffold.gemspec
+++ b/active_scaffold.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   # Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity.
   # It encourages beautiful code by favoring convention over configuration.
-  s.add_runtime_dependency('rails', '>= 4.0.5', '< 5.2.0')
+  s.add_runtime_dependency('rails', '>= 4.0.5', '< 6.0.0')
   # Deep Freeze Ruby Objects
   s.add_runtime_dependency('ice_nine', '~> 0.11')
 end


### PR DESCRIPTION
I changed "< 5.2.0" to "< 6.0.0"  to allow 5.2  maintenance releases to work.  Otherwise, rails 5.2.3 was being limited to active_scaffold 3.5.2 