### PR TITLE
Add ActiveStorage Support (609)

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -107,7 +107,8 @@ de:
       other: "%{count} %{model} makriert"
     refresh: Neu laden
     remove: Entfernen
-    remove_file: Entferne oder Ersetze Datei
+    remove_file: Entferne oder Ersetzte Datei
+    remove_files: Entfernen oder Hinzufügen Dateien
     replace_existing: Existierenden ersetzen
     replace_with_new: Mit Neuer ersetzen
     reset: Zurücksetzen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
     refresh: Refresh
     remove: Remove
     remove_file: Remove or Replace file
+    remove_files: Remove or Add files
     replace_existing: Replace Existing
     replace_with_new: Replace With New
     reset: Reset

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -110,7 +110,7 @@ es:
     refresh: Recargar
     remove: Eliminar
     remove_file: Eliminar o Reemplazar archivo
-    remove_files: Eliminar o Añadir archivo
+    remove_files: Eliminar o Añadir archivos
     replace_existing: Reemplazar existente
     replace_with_new: Reemplazar con Nuevo
     reset: Restaurar

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -110,6 +110,7 @@ es:
     refresh: Recargar
     remove: Eliminar
     remove_file: Eliminar o Reemplazar archivo
+    remove_files: Eliminar o Añadir archivo
     replace_existing: Reemplazar existente
     replace_with_new: Reemplazar con Nuevo
     reset: Restaurar

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -107,7 +107,8 @@ fr:
       other: "%{count} %{model} marqués"
     refresh: Rafraîchir
     remove: Supprimer
-    remove_file: Supprimer et remplacer le fichier
+    remove_file: Supprimer ou remplacer le fichier
+    remove_files: Supprimer ou Ajouter des fichiers
     replace_existing: Remplacer existant(e)
     replace_with_new: Remplacer avec le nouveau
     reset: Annuler

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -108,6 +108,7 @@ hu:
     refresh: Frissítés
     remove: Törlés
     remove_file: Fájl törlése, vagy cseréje
+    remove_files: Fájlok törlése, vagy hozzáadása
     replace_existing: Replace existing
     replace_with_new: Csere újjal
     reset: Alapállapot

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -108,6 +108,7 @@ ja:
     refresh: Refresh
     remove: 削除
     remove_file: ファイルを削除または置換
+    remove_files: ファイルを削除または追加する
     replace_existing: Replace existing
     replace_with_new: 新しいもので置換
     reset: リセット

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -116,6 +116,7 @@ ru:
     refresh: Обновить
     remove: Удалить
     remove_file: Удалить или заменить файл
+    remove_files: Удалить или Добавить файлы
     replace_existing: Заменить существующим
     replace_with_new: Заменить новым
     reset: Сброс

--- a/lib/active_scaffold/bridges/active_storage.rb
+++ b/lib/active_scaffold/bridges/active_storage.rb
@@ -1,0 +1,12 @@
+class ActiveScaffold::Bridges::ActiveStorage < ActiveScaffold::DataStructures::Bridge
+  def self.install
+    if ActiveScaffold::Config::Core.method_defined?(:initialize_with_active_storage)
+      raise "We've detected that you have active_scaffold_active_storage_bridge installed. This plugin has been moved to core. Please remove active_scaffold_active_storage_bridge to prevent any conflicts"
+    end
+    require File.join(File.dirname(__FILE__), 'active_storage/active_storage_bridge')
+    require File.join(File.dirname(__FILE__), 'active_storage/form_ui')
+    require File.join(File.dirname(__FILE__), 'active_storage/list_ui')
+    require File.join(File.dirname(__FILE__), 'active_storage/active_storage_helpers')
+    ActiveScaffold::Config::Core.send :prepend, ActiveScaffold::Bridges::ActiveStorage::ActiveStorageBridge
+  end
+end

--- a/lib/active_scaffold/bridges/active_storage.rb
+++ b/lib/active_scaffold/bridges/active_storage.rb
@@ -1,12 +1,6 @@
 class ActiveScaffold::Bridges::ActiveStorage < ActiveScaffold::DataStructures::Bridge
   def self.install
-    if ActiveScaffold::Config::Core.method_defined?(:initialize_with_active_storage)
-      raise "We've detected that you have active_scaffold_active_storage_bridge installed. This plugin has been moved to core. Please remove active_scaffold_active_storage_bridge to prevent any conflicts"
-    end
-    require File.join(File.dirname(__FILE__), 'active_storage/active_storage_bridge')
-    require File.join(File.dirname(__FILE__), 'active_storage/form_ui')
-    require File.join(File.dirname(__FILE__), 'active_storage/list_ui')
-    require File.join(File.dirname(__FILE__), 'active_storage/active_storage_helpers')
+    Dir[File.join(__dir__, 'active_storage', '*.rb')].each { |file| require file }
     ActiveScaffold::Config::Core.send :prepend, ActiveScaffold::Bridges::ActiveStorage::ActiveStorageBridge
   end
 end

--- a/lib/active_scaffold/bridges/active_storage/active_storage_bridge.rb
+++ b/lib/active_scaffold/bridges/active_storage/active_storage_bridge.rb
@@ -1,0 +1,32 @@
+module ActiveScaffold
+  module Bridges
+    class ActiveStorage
+      module ActiveStorageBridge
+        def initialize(model_id)
+          super
+          return unless ActiveScaffold::Bridges::ActiveStorage::ActiveStorageBridgeHelpers.klass_has_active_storage_fields?(model)
+
+          model.send :extend, ActiveScaffold::Bridges::ActiveStorage::ActiveStorageBridgeHelpers
+
+          # include the "delete" helpers for use with active scaffold, unless they are already included
+          model.generate_delete_helpers
+
+          update.multipart = true
+          create.multipart = true
+
+          model.active_storage_fields.each do |field|
+            configure_active_storage_field(field.to_sym)
+          end
+        end
+
+        private
+
+        def configure_active_storage_field(field)
+          columns << field
+          columns[field].form_ui ||= :active_storage
+          columns[field].params.add "delete_#{field}"
+        end
+      end
+    end
+  end
+end

--- a/lib/active_scaffold/bridges/active_storage/active_storage_bridge.rb
+++ b/lib/active_scaffold/bridges/active_storage/active_storage_bridge.rb
@@ -14,16 +14,25 @@ module ActiveScaffold
           update.multipart = true
           create.multipart = true
 
-          model.active_storage_fields.each do |field|
-            configure_active_storage_field(field.to_sym)
-          end
+          model.active_storage_has_one_fields.each { |field| configure_active_storage_has_one_field(field.to_sym) }
+          model.active_storage_has_many_fields.each { |field| configure_active_storage_has_many_field(field.to_sym) }
         end
 
         private
 
-        def configure_active_storage_field(field)
+        def configure_active_storage_has_one_field(field)
           columns << field
-          columns[field].form_ui ||= :active_storage
+          columns.exclude "#{field}_attachment".to_sym
+          columns.exclude "#{field}_blob".to_sym
+          columns[field].form_ui ||= :active_storage_has_one
+          columns[field].params.add "delete_#{field}"
+        end
+
+        def configure_active_storage_has_many_field(field)
+          columns << field
+          columns.exclude "#{field}_attachments".to_sym
+          columns.exclude "#{field}_blobs".to_sym
+          columns[field].form_ui ||= :active_storage_has_many
           columns[field].params.add "delete_#{field}"
         end
       end

--- a/lib/active_scaffold/bridges/active_storage/active_storage_bridge.rb
+++ b/lib/active_scaffold/bridges/active_storage/active_storage_bridge.rb
@@ -14,25 +14,17 @@ module ActiveScaffold
           update.multipart = true
           create.multipart = true
 
-          model.active_storage_has_one_fields.each { |field| configure_active_storage_has_one_field(field.to_sym) }
-          model.active_storage_has_many_fields.each { |field| configure_active_storage_has_many_field(field.to_sym) }
+          model.active_storage_has_one_fields.each { |field| configure_active_storage_field(field.to_sym, :has_one) }
+          model.active_storage_has_many_fields.each { |field| configure_active_storage_field(field.to_sym, :has_many) }
         end
 
         private
 
-        def configure_active_storage_has_one_field(field)
+        def configure_active_storage_field(field, field_type)
           columns << field
-          columns.exclude "#{field}_attachment".to_sym
-          columns.exclude "#{field}_blob".to_sym
-          columns[field].form_ui ||= :active_storage_has_one
-          columns[field].params.add "delete_#{field}"
-        end
-
-        def configure_active_storage_has_many_field(field)
-          columns << field
-          columns.exclude "#{field}_attachments".to_sym
-          columns.exclude "#{field}_blobs".to_sym
-          columns[field].form_ui ||= :active_storage_has_many
+          columns.exclude (field_type == :has_many ? "#{field}_attachments" : "#{field}_attachment").to_sym
+          columns.exclude (field_type == :has_many ? "#{field}_blobs" : "#{field}_blob").to_sym
+          columns[field].form_ui ||= "active_storage_#{field_type}".to_sym
           columns[field].params.add "delete_#{field}"
         end
       end

--- a/lib/active_scaffold/bridges/active_storage/active_storage_helpers.rb
+++ b/lib/active_scaffold/bridges/active_storage/active_storage_helpers.rb
@@ -1,0 +1,43 @@
+module ActiveScaffold
+  module Bridges
+    class ActiveStorage
+      module ActiveStorageBridgeHelpers
+        class << self
+          # From active_storage/attached/macros
+          # has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: false
+          def active_storage_fields(klass)
+            klass.reflect_on_all_associations(:has_one)&.select { |reflection| reflection.class_name == 'ActiveStorage::Attachment' } &.collect { |association| association.name[0..-12] }
+          end
+
+          def generate_delete_helpers(klass)
+            active_storage_fields(klass).each do |field|
+              klass.send :class_eval, <<-CODE, __FILE__, __LINE__ + 1 unless klass.method_defined?(:"#{field}_with_delete=")
+                attr_reader :delete_#{field}
+
+                def delete_#{field}=(value)
+                  value = (value=="true") if String===value
+                  return unless value
+
+                  # passing nil to the file column causes the file to be deleted.
+                  self.#{field}.purge
+                end
+              CODE
+            end
+          end
+
+          def klass_has_active_storage_fields?(klass)
+            true unless active_storage_fields(klass).empty?
+          end
+        end
+
+        def active_storage_fields
+          @active_storage_fields ||= ActiveStorageBridgeHelpers.active_storage_fields(self)
+        end
+
+        def generate_delete_helpers
+          ActiveStorageBridgeHelpers.generate_delete_helpers(self)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_scaffold/bridges/active_storage/form_ui.rb
+++ b/lib/active_scaffold/bridges/active_storage/form_ui.rb
@@ -1,0 +1,13 @@
+module ActiveScaffold
+  module Helpers
+    # Helpers that assist with the rendering of a Form Column
+    module FormColumnHelpers
+      def active_scaffold_input_active_storage(column, options)
+        record = options[:object]
+        active_storage = record.send(column.name.to_s)
+        content = active_scaffold_column_active_storage(record, column) if active_storage.attached?
+        active_scaffold_file_with_remove_link(column, options, content, 'delete_', 'active_storage_controls')
+      end
+    end
+  end
+end

--- a/lib/active_scaffold/bridges/active_storage/form_ui.rb
+++ b/lib/active_scaffold/bridges/active_storage/form_ui.rb
@@ -2,10 +2,19 @@ module ActiveScaffold
   module Helpers
     # Helpers that assist with the rendering of a Form Column
     module FormColumnHelpers
-      def active_scaffold_input_active_storage(column, options)
+      def active_scaffold_input_active_storage_has_one(column, options)
         record = options[:object]
         active_storage = record.send(column.name.to_s)
-        content = active_scaffold_column_active_storage(record, column) if active_storage.attached?
+        content = active_scaffold_column_active_storage_has_one(record, column) if active_storage.attached?
+        active_scaffold_file_with_remove_link(column, options, content, 'delete_', 'active_storage_controls')
+      end
+
+      def active_scaffold_input_active_storage_has_many(column, options)
+        record = options[:object]
+        options[:multiple] = 'multiple'
+        options[:name] += '[]'
+        active_storage = record.send(column.name.to_s)
+        content = active_scaffold_column_active_storage_has_many(record, column) if active_storage.attached?
         active_scaffold_file_with_remove_link(column, options, content, 'delete_', 'active_storage_controls')
       end
     end

--- a/lib/active_scaffold/bridges/active_storage/list_ui.rb
+++ b/lib/active_scaffold/bridges/active_storage/list_ui.rb
@@ -1,11 +1,28 @@
 module ActiveScaffold
   module Helpers
     module ListColumnHelpers
-      def active_scaffold_column_active_storage(record, column)
-        active_storage = record.send(column.name.to_s)
-        return nil unless active_storage.attached?
+      def active_scaffold_column_active_storage_has_one(record, column)
+        attachment = record.send(column.name.to_s)
+        attachment.attached? ? link_for_attachment(attachment) : nil
+      end
 
-        link_to(active_storage.filename, rails_blob_url(active_storage, disposition: 'attachment'), target: '_blank')
+      def active_scaffold_column_active_storage_has_many(record, column)
+        active_storage_files = record.send(column.name.to_s)
+        return nil unless active_storage_files.attached?
+
+        attachments = active_storage_files.attachments
+        if attachments.size <= 3 # Lets display up to three links, otherwise just show the count.
+          links = attachments.map { |attachment| link_for_attachment(attachment) }
+          safe_join links, association_join_text
+        else
+          pluralize attachments.size, column.name.to_s
+        end
+      end
+
+      private
+
+      def link_for_attachment(attachment)
+        link_to(attachment.filename, rails_blob_url(attachment, disposition: 'attachment'), target: '_blank')
       end
     end
   end

--- a/lib/active_scaffold/bridges/active_storage/list_ui.rb
+++ b/lib/active_scaffold/bridges/active_storage/list_ui.rb
@@ -1,0 +1,12 @@
+module ActiveScaffold
+  module Helpers
+    module ListColumnHelpers
+      def active_scaffold_column_active_storage(record, column)
+        active_storage = record.send(column.name.to_s)
+        return nil unless active_storage.attached?
+
+        link_to(active_storage.filename, rails_blob_url(active_storage, disposition: 'attachment'), target: '_blank')
+      end
+    end
+  end
+end

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -330,12 +330,13 @@ module ActiveScaffold
         object_name, method = options[:name].split(/\[(#{column.name})\]/)
         method.sub!(/#{column.name}/, "#{remove_file_prefix}\\0")
         fields = block_given? ? yield : ''
+        link_key = options[:multiple] ? :remove_files : :remove_file
         input = file_field(:record, column.name, options.merge(:onchange => js_dont_remove_file_code))
         content_tag(:div, class: controls_class) do
           content_tag(:div) do
             safe_join [content, ' | ', fields,
                        hidden_field(object_name, method, :value => 'false', class: 'remove_file'),
-                       content_tag(:a, as_(:remove_file), :href => '#', :onclick => js_remove_file_code)]
+                       content_tag(:a, as_(link_key), :href => '#', :onclick => js_remove_file_code)]
           end << content_tag(:div, input, :style => 'display: none')
         end
       end


### PR DESCRIPTION
## Requirements:
- [x] has_one_attached Support
- [x] has_many_attached Support

closes #609

---

Once merged, just install the bridge in your initializer:
```rb
#config/initializers/active_scaffold.rb
ActiveScaffold::Bridges::ActiveStorage.install
```

---

Pictures:
<img width="1088" alt="Screen Shot 2019-12-14 at 9 33 09 AM" src="https://user-images.githubusercontent.com/19609752/70850135-ebc71380-1e54-11ea-940a-4aedda591d32.png">
<img width="1085" alt="Screen Shot 2019-12-14 at 9 34 03 AM" src="https://user-images.githubusercontent.com/19609752/70850138-ebc71380-1e54-11ea-8880-7277588c9685.png">
<img width="1087" alt="Screen Shot 2019-12-14 at 9 33 39 AM" src="https://user-images.githubusercontent.com/19609752/70850136-ebc71380-1e54-11ea-9c10-0d080028fffc.png">
<img width="1082" alt="Screen Shot 2019-12-14 at 9 33 53 AM" src="https://user-images.githubusercontent.com/19609752/70850137-ebc71380-1e54-11ea-9d74-23ce35b5b76c.png">
