### PR TITLE
when you have a scoped link and a list row is updated either because …

### DIFF
--- a/lib/active_scaffold/helpers/action_link_helpers.rb
+++ b/lib/active_scaffold/helpers/action_link_helpers.rb
@@ -170,6 +170,7 @@ module ActiveScaffold
         @action_links_urls[link.name_to_cache] || begin
           url_options = cached_action_link_url_options(link, record)
           if cache_action_link_url?(link, record)
+            url_options[:id] = nil if url_options[:action] == "index"
             @action_links_urls[link.name_to_cache] = url_for(url_options)
           else
             url_options.merge! eid: nil, embedded: nil if link.nested_link?


### PR DESCRIPTION
…of an edit or a nested controller is closed the URL for the scoped link gets generated incorrectly because the original url was specific to a row so there is an :id parameter.  When doing url_for it generates the incorrect url for an index action because of the presence of the :id parameter.  So if the action is :index the :id parameter must be nil'ed out.  Not sure if this was a change in Rails 5 but here's the link to documentation mentioning this is inherent functionality in url_for.  By checking first to see if the action is an :index and explicitly setting the :id to nil resolves the problem and the url is correctly generated.