### PR TITLE
ActiveStorage - Thumbnail fix + opt out for thumbnails

### DIFF
--- a/lib/active_scaffold/bridges/active_storage/active_storage_bridge.rb
+++ b/lib/active_scaffold/bridges/active_storage/active_storage_bridge.rb
@@ -24,7 +24,7 @@ module ActiveScaffold
           columns << field
           columns.exclude "#{field}_attachment#{'s' if field_type == :has_many}".to_sym
           columns.exclude "#{field}_blob#{'s' if field_type == :has_many}".to_sym
-          columns[field].includes ||= "#{field}_attachment#{'s' if field_type == :has_many}".to_sym
+          columns[field].includes ||= ["#{field}_attachment#{'s' if field_type == :has_many}".to_sym, "#{field}_blob#{'s' if field_type == :has_many}".to_sym]
           columns[field].form_ui ||= "active_storage_#{field_type}".to_sym
           columns[field].params.add "delete_#{field}"
         end

--- a/lib/active_scaffold/bridges/active_storage/list_ui.rb
+++ b/lib/active_scaffold/bridges/active_storage/list_ui.rb
@@ -3,7 +3,7 @@ module ActiveScaffold
     module ListColumnHelpers
       def active_scaffold_column_active_storage_has_one(record, column)
         attachment = record.send(column.name.to_s)
-        attachment.attached? ? link_for_attachment(attachment) : nil
+        attachment.attached? ? link_for_attachment(attachment, column) : nil
       end
 
       def active_scaffold_column_active_storage_has_many(record, column)
@@ -12,7 +12,7 @@ module ActiveScaffold
 
         attachments = active_storage_files.attachments
         if attachments.size <= 3 # Lets display up to three links, otherwise just show the count.
-          links = attachments.map { |attachment| link_for_attachment(attachment) }
+          links = attachments.map { |attachment| link_for_attachment(attachment, column) }
           safe_join links, association_join_text(column)
         else
           pluralize attachments.size, column.name.to_s
@@ -21,7 +21,7 @@ module ActiveScaffold
 
       private
 
-      def link_for_attachment(attachment)
+      def link_for_attachment(attachment, column)
         variant = column.options[:thumb] || ActiveScaffold::Bridges::ActiveStorage::ActiveStorageBridgeHelpers.thumbnail_variant
         content =
           if variant && attachment.variable?

--- a/lib/active_scaffold/bridges/active_storage/list_ui.rb
+++ b/lib/active_scaffold/bridges/active_storage/list_ui.rb
@@ -24,7 +24,7 @@ module ActiveScaffold
       def link_for_attachment(attachment, column)
         variant = column.options[:thumb] || ActiveScaffold::Bridges::ActiveStorage::ActiveStorageBridgeHelpers.thumbnail_variant
         content =
-          if variant && attachment.variable?
+          if variant && attachment.variable? && column.options[:thumb] != false
             image_tag(attachment.variant(variant))
           else
             attachment.filename


### PR DESCRIPTION
- Adds the missing column references used when adding thumbnails

Also:
- Allows to pass `thumb: false` to not have a thumbnail. 
  - Unsolicited Reason: Currently deploying to windows :cry: and installing ImageMagick is not something we want to do at this time.
- Added Includes for Blobs as well.