### PR TITLE
fix i18n at ruby 3.0.0

### DIFF
--- a/lib/active_scaffold/extensions/localize.rb
+++ b/lib/active_scaffold/extensions/localize.rb
@@ -3,7 +3,7 @@ class Object
     if key.present?
       scope = [:active_scaffold, *options.delete(:scope)]
       options = options.reverse_merge(:scope => scope, :default => key.is_a?(String) ? key : key.to_s.titleize)
-      text = I18n.translate(key.to_s, options).html_safe # rubocop:disable Rails/OutputSafety
+      text = I18n.translate(key.to_s, **options).html_safe # rubocop:disable Rails/OutputSafety
       # text = nil if text.include?('translation missing:')
     end
     text || key


### PR DESCRIPTION
"wrong number of arguments (given 2, expected 0..1)" error message at ruby 3.0.0

https://github.com/ruby-i18n/i18n/pull/545

# environment
* ruby: 3.0.0
* rails: 6.0.3.4
* AS: master@e0a00ac
* action: index