### PR TITLE
Rails 6/6.1 compatibility improvements

### DIFF
--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -162,29 +162,33 @@ module ActionView
       include ActiveScaffold::RenderingHelper
     end
 
-    RenderingHelper.class_eval do
-      # override the render method to use our @lookup_context instead of the
-      # memoized @_lookup_context
-      def render(options = {}, locals = {}, &block)
-        case options
-        when Hash
-          in_rendering_context(options) do |renderer|
-            # previously set view paths and lookup context are lost here
-            # if you use view_renderer.render, so instead create a new renderer
-            # with our context
-            temp_renderer = ActionView::Renderer.new(@lookup_context)
-            if block_given?
-              #view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
-              temp_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
-            else
-              #view_renderer.render(self, options)
-              temp_renderer.render(self, options)
+    if Gem.loaded_specs["rails"].version.segments.first >= 6
+
+      RenderingHelper.class_eval do
+        # override the render method to use our @lookup_context instead of the
+        # memoized @_lookup_context
+        def render(options = {}, locals = {}, &block)
+          case options
+          when Hash
+            in_rendering_context(options) do |renderer|
+              # previously set view paths and lookup context are lost here
+              # if you use view_renderer, so instead create a new renderer
+              # with our context
+              temp_renderer = ActionView::Renderer.new(@lookup_context)
+              if block_given?
+                #view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
+                temp_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
+              else
+                #view_renderer.render(self, options)
+                temp_renderer.render(self, options)
+              end
             end
+          else
+            view_renderer.render_partial(self, partial: options, locals: locals, &block)
           end
-        else
-          view_renderer.render_partial(self, partial: options, locals: locals, &block)
         end
       end
+      
     end
   end
 end

--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -66,10 +66,9 @@ module ActiveScaffold #:nodoc:
           else
             last_view_path = File.expand_path(File.dirname(File.dirname(lookup_context.last_template.inspect)), Rails.root)
           end
-          last_view_path = File.expand_path(File.dirname(File.dirname(lookup_context.last_template.inspect)), Rails.root)
           new_view_paths = view_paths.drop(view_paths.find_index { |path| path.to_s == last_view_path } + 1)
           if @lookup_context # rails 6
-            if respond_to? build_lookup_context # rails 6.0
+            if respond_to? :build_lookup_context # rails 6.0
               build_lookup_context(new_view_paths)
             else # rails 6.1
               @lookup_context = ActionView::LookupContext.new(new_view_paths)

--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -164,20 +164,21 @@ module ActionView
 
     RenderingHelper.class_eval do
       # override the render method to use our @lookup_context instead of the
-      # memoized @_lookup_context present on the
+      # memoized @_lookup_context
       def render(options = {}, locals = {}, &block)
         case options
         when Hash
           in_rendering_context(options) do |renderer|
+            # previously set view paths and lookup context are lost here
+            # if you use view_renderer.render, so instead create a new renderer
+            # with our context
+            temp_renderer = ActionView::Renderer.new(@lookup_context)
             if block_given?
-              view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
+              #view_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
+              temp_renderer.render_partial(self, options.merge(partial: options[:layout]), &block)
             else
               #view_renderer.render(self, options)
-              # previously set view paths and lookup context are lost here
-              # if you use view_renderer.render, so instead create a new renderer
-              # with our context
-              @_view_renderer = ActionView::Renderer.new(@lookup_context)
-              @_view_renderer.render(self, options)
+              temp_renderer.render(self, options)
             end
           end
         else

--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -69,7 +69,10 @@ module ActiveScaffold #:nodoc:
           last_view_path = File.expand_path(File.dirname(File.dirname(lookup_context.last_template.inspect)), Rails.root)
           new_view_paths = view_paths.drop(view_paths.find_index { |path| path.to_s == last_view_path } + 1)
           if @lookup_context # rails 6
-            @lookup_context = ActionView::LookupContext.new(new_view_paths)
+            if respond_to? build_lookup_context # rails 6.0
+              build_lookup_context(new_view_paths)
+            else # rails 6.1
+              @lookup_context = ActionView::LookupContext.new(new_view_paths)
           else
             lookup_context.view_paths = new_view_paths
           end

--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -61,10 +61,15 @@ module ActiveScaffold #:nodoc:
           options[:prefixes] = lookup_context.prefixes.drop((lookup_context.prefixes.find_index(prefix) || -1) + 1)
         else
           options[:prefixes] = ['active_scaffold_overrides']
+          if @lookup_context # rails 6
+            last_view_path = File.expand_path(File.dirname(File.dirname(@lookup_context.last_template.short_identifier.to_s)), Rails.root)
+          else
+            last_view_path = File.expand_path(File.dirname(File.dirname(lookup_context.last_template.inspect)), Rails.root)
+          end
           last_view_path = File.expand_path(File.dirname(File.dirname(lookup_context.last_template.inspect)), Rails.root)
           new_view_paths = view_paths.drop(view_paths.find_index { |path| path.to_s == last_view_path } + 1)
-          if @lookup_context
-            @lookup_context = build_lookup_context(new_view_paths)
+          if @lookup_context # rails 6
+            @lookup_context = ActionView::LookupContext.new(new_view_paths)
           else
             lookup_context.view_paths = new_view_paths
           end

--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -73,6 +73,7 @@ module ActiveScaffold #:nodoc:
               build_lookup_context(new_view_paths)
             else # rails 6.1
               @lookup_context = ActionView::LookupContext.new(new_view_paths)
+            end
           else
             lookup_context.view_paths = new_view_paths
           end

--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -37,12 +37,21 @@ module ActiveScaffold
       # This is the template finder logic, keep it updated with however we find stuff in rails
       # currently this very similar to the logic in ActionBase::Base.render for options file
       def template_exists?(template_name, partial = false)
+        rails_major_version = Gem.loaded_specs["rails"].version.segments.first
         if @_view_paths
           restore_view_paths = lookup_context.view_paths
-          lookup_context.view_paths = @_view_paths
+          if rails_major_version >= 6
+            lookup_context.send(:build_view_paths, @_view_paths)
+          else
+            lookup_context.view_paths = @_view_paths
+          end
         end
         lookup_context.exists?(template_name, '', partial).tap do
-          lookup_context.view_paths = restore_view_paths if @_view_paths
+          if rails_major_version >= 6
+            lookup_context.send(:build_view_paths, restore_view_paths)
+          else
+            lookup_context.view_paths = restore_view_paths if @_view_paths
+          end
         end
       end
 

--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -46,7 +46,7 @@ module ActiveScaffold
             lookup_context.view_paths = @_view_paths
           end
         end
-        lookup_context.exists?(template_name, '', partial).tap do
+        (@_lookup_context || lookup_context).exists?(template_name, '', partial).tap do
           if majorv >= 6 && minorv >= 1
             lookup_context.send(:build_view_paths, restore_view_paths)
           else

--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -37,17 +37,17 @@ module ActiveScaffold
       # This is the template finder logic, keep it updated with however we find stuff in rails
       # currently this very similar to the logic in ActionBase::Base.render for options file
       def template_exists?(template_name, partial = false)
-        rails_major_version = Gem.loaded_specs["rails"].version.segments.first
+        majorv, minorv, patchv = Gem.loaded_specs["rails"].version.segments
         if @_view_paths
           restore_view_paths = lookup_context.view_paths
-          if rails_major_version >= 6
+          if majorv >= 6 && minorv >= 1
             lookup_context.send(:build_view_paths, @_view_paths)
           else
             lookup_context.view_paths = @_view_paths
           end
         end
         lookup_context.exists?(template_name, '', partial).tap do
-          if rails_major_version >= 6
+          if majorv >= 6 && minorv >= 1
             lookup_context.send(:build_view_paths, restore_view_paths)
           else
             lookup_context.view_paths = restore_view_paths if @_view_paths


### PR DESCRIPTION
When upgrading our app to rails 6.1 we encountered some issues when rendering scaffolds.  

We then downgraded to rails 6.0 and still had problems due to our use of active_scaffold_batch gem.  It appears that when views attempted to call `render :super` the partial lookup process failed.  After debugging we found this was due in part to a change in the ActionView::Template `inspect` method, and 6.0 should now use the `short_identifier` instead.

Additionally the ActionView::Helpers::RenderingHelper render method was losing the lookup context that gets set in active scaffold's render method because it uses the memoized @_view_renderer which doesn't include our @lookup_context.

This addresses these issues as well as some minor fixes for running on rails 6.1, but we will stick with 6.0 for now.