### PR TITLE
Display group cols vertically when col layout is vertical

### DIFF
--- a/app/views/active_scaffold_overrides/_form_association_record.html.erb
+++ b/app/views/active_scaffold_overrides/_form_association_record.html.erb
@@ -84,10 +84,18 @@
 
   <% columns_groups.each do |columns_group| %>
   <%= content_tag row_tag, :class => 'associated-record' do %>
-    <%= content_tag column_tag, :colspan => (columns_length if column_tag == :td) do %>
-    <% columns_group.each_column(for: record.class, crud_type: :read, flatten: true) do |col| %>
-      <%= active_scaffold_render_subform_column(col, scope, crud_type, readonly, true, record) %>
-    <% end %>
+    <% if layout == :vertical %>
+      <% columns_group.each_column(for: record.class, crud_type: :read, flatten: true) do |col| %>
+        <%= content_tag column_tag, :class => 'form-element', :colspan => (columns_length if column_tag == :td) do %>
+          <%= active_scaffold_render_subform_column(col, scope, crud_type, readonly, false, record) %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%= content_tag column_tag, :colspan => (columns_length if column_tag == :td) do %>
+      <% columns_group.each_column(for: record.class, crud_type: :read, flatten: true) do |col| %>
+        <%= active_scaffold_render_subform_column(col, scope, crud_type, readonly, true, record) %>
+      <% end %>
+      <% end %>
     <% end %>
   <% end %>
   <% end %>

--- a/app/views/active_scaffold_overrides/_form_association_record.html.erb
+++ b/app/views/active_scaffold_overrides/_form_association_record.html.erb
@@ -86,7 +86,13 @@
   <%= content_tag row_tag, :class => 'associated-record' do %>
     <% if layout == :vertical %>
       <% columns_group.each_column(for: record.class, crud_type: :read, flatten: true) do |col| %>
-        <%= content_tag column_tag, :class => 'form-element', :colspan => (columns_length if column_tag == :td) do %>
+        <%
+          col_class = default_col_class.clone
+          col_class << 'required' if col.required?
+          col_class << col.css_class unless col.css_class.nil? || col.css_class.is_a?(Proc)
+          col_class << 'hidden' if column_renders_as(col) == :hidden
+        %>
+        <%= content_tag column_tag, :class => col_class, :colspan => (columns_length if column_tag == :td) do %>
           <%= active_scaffold_render_subform_column(col, scope, crud_type, readonly, false, record) %>
         <% end %>
       <% end %>


### PR DESCRIPTION
If a scaffold association column has its layout configured as vertical,
the subform fields are displayed vertically, except when the fields are
within a column group.  Fix by including a column_tag for each column
instead of one parent column_tag containing all the subform columns.