### PR TITLE
Ruby 3: Fix "wrong number of arguments (given 1, expected 0)"

### DIFF
--- a/lib/active_scaffold/extensions/unsaved_record.rb
+++ b/lib/active_scaffold/extensions/unsaved_record.rb
@@ -11,7 +11,7 @@ module ActiveScaffold::UnsavedRecord
   end
 
   # automatically unsets the unsaved flag
-  def save(*)
+  ruby2_keywords def save(*)
     super.tap { self.unsaved = false }
   end
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/611746/124519700-ad36d800-ddaf-11eb-8d05-a1d02b455bb9.png)

When I first looked at it, ActiveScaffold being somewhere close to the top of the stacktrace drew my attention. Then seeing the method definition with `*` made me immediately sure it's the cause of the problem due to recent changes in how Ruby 3 handles arguments. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

To validate, I went to `lib/active_scaffold/extensions/unsaved_record.rb` and commented out `dev save(*)` method and the code would no longer throw an exception.

```ruby
  # def save(*)
  #   super.tap { self.unsaved = false }
  # end
```

Environment: Rails 6.0.4, Ruby 3.0.1.

Note: Accepting this PR will make AS stop working on Ruby 2.5 and below. If you prefer a solution that respects older Ruby versions, please let me know and I'll add the required code for backwards compatibility.
