### PR TITLE
Feature/tinymce bridge js settings

### DIFF
--- a/app/assets/javascripts/jquery/active_scaffold_chosen.js
+++ b/app/assets/javascripts/jquery/active_scaffold_chosen.js
@@ -1,14 +1,16 @@
+var chosen_options = {};
+
 jQuery(document).ready(function() {
   jQuery(document).on('as:element_updated as:element_created', function(event) {
-    jQuery('select.chosen', event.target).chosen();
+    jQuery('select.chosen', event.target).chosen(chosen_options);
   });
   jQuery(document).on('as:action_success', 'a.as_action', function(event, action_link) {
     if (action_link.adapter) {
-      jQuery('select.chosen', action_link.adapter).chosen();
+      jQuery('select.chosen', action_link.adapter).chosen(chosen_options);
     }
   });
-  jQuery('select.chosen').chosen();
+  jQuery('select.chosen').chosen(chosen_options);
   jQuery(document).on('turbolinks:load', function($) {
-      jQuery('select.chosen').chosen();
+      jQuery('select.chosen').chosen(chosen_options);
   });
 });

--- a/app/assets/javascripts/jquery/active_scaffold_chosen.js
+++ b/app/assets/javascripts/jquery/active_scaffold_chosen.js
@@ -1,4 +1,4 @@
-var chosen_options = {};
+chosen_options = {};
 
 jQuery(document).ready(function() {
   jQuery(document).on('as:element_updated as:element_created', function(event) {
@@ -11,6 +11,6 @@ jQuery(document).ready(function() {
   });
   jQuery('select.chosen').chosen(chosen_options);
   jQuery(document).on('turbolinks:load', function($) {
-      jQuery('select.chosen').chosen(chosen_options);
+    jQuery('select.chosen').chosen(chosen_options);
   });
 });

--- a/app/assets/javascripts/jquery/active_scaffold_chosen.js
+++ b/app/assets/javascripts/jquery/active_scaffold_chosen.js
@@ -1,5 +1,3 @@
-chosen_options = {};
-
 jQuery(document).ready(function() {
   jQuery(document).on('as:element_updated as:element_created', function(event) {
     jQuery('select.chosen', event.target).chosen(chosen_options);

--- a/app/assets/javascripts/jquery/active_scaffold_chosen_options.js
+++ b/app/assets/javascripts/jquery/active_scaffold_chosen_options.js
@@ -1,0 +1,1 @@
+chosen_options = {};

--- a/app/assets/javascripts/jquery/tiny_mce_bridge.js
+++ b/app/assets/javascripts/jquery/tiny_mce_bridge.js
@@ -1,3 +1,5 @@
+var tiny_mce_settings = {};
+
 (function() {
   var action_link_close = ActiveScaffold.ActionLink.Abstract.prototype.close;
   ActiveScaffold.ActionLink.Abstract.prototype.close = function() {
@@ -9,7 +11,9 @@
 
   function loadTinyMCE() {
     var settings = jQuery(this).data('tinymce');
-    if (tiny_mce_settings) settings += tiny_mce_settings;
+    for (key in tiny_mce_settings) {
+      settings[key] = tiny_mce_settings[key];
+    }
     if (settings) tinyMCE.settings = settings;
     tinyMCE.execCommand('mceAddEditor', false, jQuery(this).attr('id'));
   }

--- a/app/assets/javascripts/jquery/tiny_mce_bridge.js
+++ b/app/assets/javascripts/jquery/tiny_mce_bridge.js
@@ -9,6 +9,7 @@
 
   function loadTinyMCE() {
     var settings = jQuery(this).data('tinymce');
+    if (tiny_mce_settings) settings += tiny_mce_settings;
     if (settings) tinyMCE.settings = settings;
     tinyMCE.execCommand('mceAddEditor', false, jQuery(this).attr('id'));
   }

--- a/app/assets/javascripts/jquery/tiny_mce_bridge.js
+++ b/app/assets/javascripts/jquery/tiny_mce_bridge.js
@@ -1,4 +1,4 @@
-var tiny_mce_settings = {};
+tiny_mce_settings = {};
 
 (function() {
   var action_link_close = ActiveScaffold.ActionLink.Abstract.prototype.close;

--- a/app/assets/javascripts/jquery/tiny_mce_bridge.js
+++ b/app/assets/javascripts/jquery/tiny_mce_bridge.js
@@ -1,5 +1,3 @@
-tiny_mce_settings = {};
-
 (function() {
   var action_link_close = ActiveScaffold.ActionLink.Abstract.prototype.close;
   ActiveScaffold.ActionLink.Abstract.prototype.close = function() {

--- a/app/assets/javascripts/jquery/tiny_mce_bridge_settings.js
+++ b/app/assets/javascripts/jquery/tiny_mce_bridge_settings.js
@@ -1,0 +1,1 @@
+tiny_mce_settings = {};

--- a/lib/active_scaffold/bridges/chosen.rb
+++ b/lib/active_scaffold/bridges/chosen.rb
@@ -12,6 +12,8 @@ class ActiveScaffold::Bridges::Chosen < ActiveScaffold::DataStructures::Bridge
   end
 
   def self.javascripts
-    ["chosen-#{ActiveScaffold.js_framework}", "#{ActiveScaffold.js_framework}/active_scaffold_chosen"]
+    ["chosen-#{ActiveScaffold.js_framework}",
+     "#{ActiveScaffold.js_framework}/active_scaffold_chosen",
+     "#{ActiveScaffold.js_framework}/active_scaffold_chosen_options"]
   end
 end

--- a/lib/active_scaffold/bridges/tiny_mce.rb
+++ b/lib/active_scaffold/bridges/tiny_mce.rb
@@ -11,7 +11,7 @@ class ActiveScaffold::Bridges::TinyMce < ActiveScaffold::DataStructures::Bridge
   def self.javascripts
     case ActiveScaffold.js_framework
     when :jquery
-      ['tinymce-jquery', 'jquery/tiny_mce_bridge']
+      ['tinymce-jquery', 'jquery/tiny_mce_bridge', 'jquery/tiny_mce_bridge_settings']
     when :prototype
       ['tinymce', 'prototype/tiny_mce_bridge']
     end


### PR DESCRIPTION
Here are some code changes I made so that the issues presented in #668 are fixed.

The trick I used was to create 2 new JS files, one for Chosen, the other for Tiny MCE, storing an empty JS map each.
These 2 JS maps are then used by the JS code to instantiate Chosen with the specified options and to expand the Tiny MCE settings loaded from the `tinymce.yml` file.

At first glance, this has no effect, since the 2 JS maps are empty. However, since they each reside in an empty file, these files can be overloaded by the user and he/she can freely populate the JS hashes with the custom settings required by their project.

Please take the time to test the code.
Thank you!