### PR TITLE
Search form fixes for Rails UJS

### DIFF
--- a/app/views/active_scaffold_overrides/_field_search.html.erb
+++ b/app/views/active_scaffold_overrides/_field_search.html.erb
@@ -1,5 +1,5 @@
 <%
-  url_options ||= params_for(action: :index)
+  url_options ||= params_for(action: :index, id: nil, search: nil)
   submit_text ||= :search
   xhr ||= request.xhr?
   options = {
@@ -10,7 +10,7 @@
     method: :get
   }
   
-  hidden_params = url_options.except(:controller, :action).to_query.split(Rack::Utils::DEFAULT_SEP)
+  hidden_params = url_options.except(:controller, :action, :id, :search).to_query.split(Rack::Utils::DEFAULT_SEP)
 -%>
 
 <%= form_tag url_options, options %>

--- a/app/views/active_scaffold_overrides/_field_search.html.erb
+++ b/app/views/active_scaffold_overrides/_field_search.html.erb
@@ -1,5 +1,5 @@
 <%
-  url_options ||= params_for(action: :index, id: nil, search: nil)
+  url_options ||= params_for(action: :index)
   submit_text ||= :search
   xhr ||= request.xhr?
   options = {
@@ -10,7 +10,7 @@
     method: :get
   }
   
-  hidden_params = params_for(action: :index).except(:controller, :action).to_query.split(Rack::Utils::DEFAULT_SEP)
+  hidden_params = url_options.except(:controller, :action).to_query.split(Rack::Utils::DEFAULT_SEP)
 -%>
 
 <%= form_tag url_options, options %>

--- a/app/views/active_scaffold_overrides/_field_search.html.erb
+++ b/app/views/active_scaffold_overrides/_field_search.html.erb
@@ -9,8 +9,16 @@
     data: {loading: true},
     method: :get
   }
+  
+  hidden_params = params_for(action: :index).except(:controller, :action).to_query.split(Rack::Utils::DEFAULT_SEP)
 -%>
+
 <%= form_tag url_options, options %>
+  <% hidden_params.each do |pair| -%>
+    <% key, value = pair.split('=', 2).map { |str| Rack::Utils.unescape(str) } -%>
+    <%= hidden_field_tag(key, value) %>
+  <% end -%>
+  
   <ol class="form">
     <% visibles, hiddens = visibles_and_hiddens(active_scaffold_config.field_search) %>
     <% visibles.each do |column| -%>

--- a/app/views/active_scaffold_overrides/_search.html.erb
+++ b/app/views/active_scaffold_overrides/_search.html.erb
@@ -1,6 +1,6 @@
 <%
   live_search = active_scaffold_config.search.live?
-  url_options =  params_for(action: :index, id: nil, search: nil)
+  url_options =  params_for(action: :index)
   submit_text ||= :search
   xhr ||= request.xhr?
   options = {
@@ -11,7 +11,7 @@
     method: :get
   }
   
-  hidden_params = params_for(action: :index).except(:controller, :action).to_query.split(Rack::Utils::DEFAULT_SEP)
+  hidden_params = url_options.except(:controller, :action).to_query.split(Rack::Utils::DEFAULT_SEP)
 -%>
 
 <%= form_tag url_options, options do %>

--- a/app/views/active_scaffold_overrides/_search.html.erb
+++ b/app/views/active_scaffold_overrides/_search.html.erb
@@ -10,8 +10,15 @@
     data: {loading: true},
     method: :get
   }
+  
+  hidden_params = params_for(action: :index).except(:controller, :action).to_query.split(Rack::Utils::DEFAULT_SEP)
 -%>
+
 <%= form_tag url_options, options do %>
+  <% hidden_params.each do |pair| -%>
+    <% key, value = pair.split('=', 2).map { |str| Rack::Utils.unescape(str) } -%>
+    <%= hidden_field_tag(key, value) %>
+  <% end -%>
   <%= search_field_tag :search, (search_params if search_params.is_a? String), :class => 'text-input', :id => search_input_id, :size => 50, :autocomplete => :off, :placeholder => as_(live_search ? :live_search : :search_terms) %>
   <%= submit_tag as_(submit_text), :class => "submit", :style => ('display:none;' if live_search) %>
   <%= link_to as_(:reset), url_for(url_options.merge(:search => '')), :class => 'as_cancel reset', :remote => true, :data => {:refresh => true} unless local_assigns[:skip_reset] %>

--- a/app/views/active_scaffold_overrides/_search.html.erb
+++ b/app/views/active_scaffold_overrides/_search.html.erb
@@ -1,6 +1,6 @@
 <%
   live_search = active_scaffold_config.search.live?
-  url_options =  params_for(action: :index)
+  url_options =  params_for(action: :index, id: nil, search: nil)
   submit_text ||= :search
   xhr ||= request.xhr?
   options = {
@@ -11,7 +11,7 @@
     method: :get
   }
   
-  hidden_params = url_options.except(:controller, :action).to_query.split(Rack::Utils::DEFAULT_SEP)
+  hidden_params = url_options.except(:controller, :action, :id, :search).to_query.split(Rack::Utils::DEFAULT_SEP)
 -%>
 
 <%= form_tag url_options, options do %>


### PR DESCRIPTION
Rails UJS apparently discards form action url query parameters when submitting a form, resulting in constraints, embedded info and eid being lost. This update adds the params as hidden fields to work around this problem.

Fixes issue #673.

I don't have any projects using jquery-ujs to test against. However, jquery-ujs supports form field values, and the form action url already contains the `search` parameter, so this shouldn't cause any problems.