### PR TITLE
Preventing NoMethodError:  undefined method `match?' for nil:NilClass

### DIFF
--- a/lib/active_scaffold/actions/core.rb
+++ b/lib/active_scaffold/actions/core.rb
@@ -320,6 +320,7 @@ module ActiveScaffold::Actions
 
     def check_input_device
       return unless session[:input_device_type].nil?
+      return if request.env['HTTP_USER_AGENT'].nil?
       if request.env['HTTP_USER_AGENT'].match?(/(iPhone|iPod|iPad)/i)
         session[:input_device_type] = 'TOUCH'
         session[:hover_supported] = false


### PR DESCRIPTION
Add a guard protection.