### PR TITLE
Adjust use of `field_error_proc` to work with Rails 7.

### DIFF
--- a/lib/active_scaffold/bridges/record_select/helpers.rb
+++ b/lib/active_scaffold/bridges/record_select/helpers.rb
@@ -51,7 +51,7 @@ class ActiveScaffold::Bridges::RecordSelect
           else
             record_select_field(options[:name], value || klass.new, record_select_options)
           end
-        html = self.class.field_error_proc.call(html, self) if record.errors[column.name].any?
+        html = self.instance_exec(html, self, &self.class.field_error_proc) if record.errors[column.name].any?
         html
       end
 
@@ -60,7 +60,7 @@ class ActiveScaffold::Bridges::RecordSelect
           :controller => active_scaffold_controller_for(record.class).controller_path
         ).merge(column.options)
         html = record_select_autocomplete(options[:name], record, record_select_options)
-        html = self.class.field_error_proc.call(html, self) if record.errors[column.name].any?
+        html = self.instance_exec(html, self, &self.class.field_error_proc) if record.errors[column.name].any?
         html
       end
     end


### PR DESCRIPTION
https://github.com/rails/rails/issues/45165

Rails changed their `field_error_proc` in a way that breaks active scaffold. They say it's not a public API and therefore will not change it back.

This PR adjusts the usage of the `field_error_proc` to work with Rails 7 (I also think it fixes an issue in 6.1.x which backported the change from the main branch).