### PR TITLE
Adjust keeping_errors to work with rails >6.1 new error objects.

### DIFF
--- a/lib/active_scaffold/extensions/unsaved_record.rb
+++ b/lib/active_scaffold/extensions/unsaved_record.rb
@@ -18,8 +18,14 @@ module ActiveScaffold::UnsavedRecord
   def keeping_errors
     old_errors = errors.dup if errors.present?
     result = yield
-    old_errors&.each do |attr|
-      old_errors[attr].each { |msg| errors.add(attr, msg) unless errors.added?(attr, msg) }
+    old_errors&.each do |e|
+      if e.is_a?(String) || e.is_a?(Symbol)
+        # Rails <6.1 errors API.
+        old_errors[e].each { |msg| errors.add(e, msg) unless errors.added?(e, msg) }
+      else
+        # Rails >=6.1 errors API (https://code.lulalala.com/2020/0531-1013.html).
+        errors.add(e.attribute, e.message) unless errors.added?(e.attribute, e.message)
+      end
     end
     result && old_errors.blank?
   end


### PR DESCRIPTION
Rails >6.1 has adjusted their error object API (summary is here: https://code.lulalala.com/2020/0531-1013.html and here: https://github.com/rails/rails/blob/6-1-stable/activemodel/CHANGELOG.md#rails-610-december-09-2020).

This PR adjusts the `keeping_errors` method to work with this new API.