### PR TITLE
Add hide_column_if Column attr_accessor

### DIFF
--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -87,6 +87,16 @@ module ActiveScaffold::DataStructures
     cattr_accessor :send_form_on_update_column, instance_accessor: false
     attr_accessor :send_form_on_update_column
 
+    # add a custom attr_accessor that can contain a Proc (or boolean) that will
+    # be called when the column renders, such that we can dynamically hide or
+    # show the column with an element that can be replaced by update_columns,
+    # but won't affect the form submission.
+    # The value can be set in the scaffold controller as follows:
+    # config.columns[:my_column].hide_column_if = Proc.new { |record, column, scope| record.should_be_hidden? }
+    # OR
+    # config.columns[:my_column].hide_column_if = true
+    attr_accessor :hide_column_if
+
     # sorting on a column can be configured four ways:
     #   sort = true               default, uses intelligent sorting sql default
     #   sort = false              sometimes sorting doesn't make sense

--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -87,14 +87,17 @@ module ActiveScaffold::DataStructures
     cattr_accessor :send_form_on_update_column, instance_accessor: false
     attr_accessor :send_form_on_update_column
 
-    # add a custom attr_accessor that can contain a Proc (or boolean) that will
-    # be called when the column renders, such that we can dynamically hide or
-    # show the column with an element that can be replaced by update_columns,
-    # but won't affect the form submission.
-    # The value can be set in the scaffold controller as follows:
-    # config.columns[:my_column].hide_form_column_if = Proc.new { |record, column, scope| record.should_be_hidden? }
-    # OR
+    # add a custom attr_accessor that can contain a Proc (or boolean or symbol)
+    # that will be called when the column renders, such that we can dynamically
+    # hide or show the column with an element that can be replaced by
+    # update_columns, but won't affect the form submission.
+    # The value can be set in the scaffold controller as follows to dynamically
+    # hide the column based on a Proc's output:
+    # config.columns[:my_column].hide_form_column_if = Proc.new { |record, column, scope| record.vehicle_type == 'tractor' }
+    # OR to always hide the column:
     # config.columns[:my_column].hide_form_column_if = true
+    # OR to call a method on the record to determine whether to hide the column:
+    # config.columns[:my_column].hide_form_column_if = :hide_tractor_fields?
     attr_accessor :hide_form_column_if
 
     # sorting on a column can be configured four ways:

--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -92,10 +92,10 @@ module ActiveScaffold::DataStructures
     # show the column with an element that can be replaced by update_columns,
     # but won't affect the form submission.
     # The value can be set in the scaffold controller as follows:
-    # config.columns[:my_column].hide_column_if = Proc.new { |record, column, scope| record.should_be_hidden? }
+    # config.columns[:my_column].hide_form_column_if = Proc.new { |record, column, scope| record.should_be_hidden? }
     # OR
-    # config.columns[:my_column].hide_column_if = true
-    attr_accessor :hide_column_if
+    # config.columns[:my_column].hide_form_column_if = true
+    attr_accessor :hide_form_column_if
 
     # sorting on a column can be configured four ways:
     #   sort = true               default, uses intelligent sorting sql default

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -152,7 +152,7 @@ module ActiveScaffold
       end
 
       def render_column(column, record, renders_as, scope = nil, only_value = false, col_class = nil) # rubocop:disable Metrics/ParameterLists
-        if (column.hide_column_if.respond_to?(:call) ? column.hide_column_if.call(record, column, scope) : column.hide_column_if)
+        if form_column_is_hidden?(column, record, scope)
           # creates an element that can be replaced by the update_columns routine,
           # but will not affect the value of the submitted form in this state:
           # <dl><input type="hidden" class="<%= column.name %>-input"></dl>
@@ -167,6 +167,20 @@ module ActiveScaffold
           render :partial => 'form_association', :locals => {:column => column, :scope => scope, :parent_record => record}
         else
           form_hidden_attribute(column, record, scope)
+        end
+      end
+
+      def form_column_is_hidden?(column, record, scope = nil)
+        if column.hide_form_column_if
+          if column.hide_form_column_if.respond_to?(:call)
+            return column.hide_form_column_if.call(record, column, scope)
+          elsif column.hide_form_column_if.is_a?(Symbol)
+            return record.send(column.hide_form_column_if)
+          else
+            return column.hide_form_column_if
+          end
+        else
+          return false
         end
       end
 

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -152,7 +152,14 @@ module ActiveScaffold
       end
 
       def render_column(column, record, renders_as, scope = nil, only_value = false, col_class = nil) # rubocop:disable Metrics/ParameterLists
-        if (partial = override_form_field_partial(column))
+        if (column.hide_column_if.respond_to?(:call) ? column.hide_column_if.call(record, column, scope) : column.hide_column_if)
+          # creates an element that can be replaced by the update_columns routine,
+          # but will not affect the value of the submitted form in this state:
+          # <dl><input type="hidden" class="<%= column.name %>-input"></dl>
+          content_tag :dl, style: 'display: none' do
+            hidden_field_tag(nil, nil, :class => "#{column.name}-input")
+          end
+        elsif (partial = override_form_field_partial(column))
           render :partial => partial, :locals => {:column => column, :only_value => only_value, :scope => scope, :col_class => col_class, :record => record}
         elsif renders_as == :field || override_form_field?(column)
           form_attribute(column, record, scope, only_value, col_class)


### PR DESCRIPTION
Add a new attr_accessor to the DataStructures::Column module to allow for calling a dynamic Proc to determine whether a form column should be shown or not.

When hidden, render a dl element that can still be re-rendered by the update_columns routine so we will re-evaluate the proc whenever the column is re-rendered.

The value can be set a Proc in the scaffold controller as follows:
```
config.columns[:my_column].hide_column_if = Proc.new { |record, column, scope| record.should_be_hidden? }
```

OR to always hide, use:
```
config.columns[:my_column].hide_column_if = true
```

This is useful when you want the column to be accessible via API but do not want it to be visible in the HTML form.