### PR TITLE
Fix label lookup process when controller doesn't match model

### DIFF
--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -144,9 +144,6 @@ module ActiveScaffold #:nodoc:
       else
         url = url_for(url_options)
         content_tag(:div, :id => id, :class => 'active-scaffold-component', :data => {:refresh => url}) do
-          # parse the ActiveRecord model name from the controller path, which
-          # might be a namespaced controller (e.g., 'admin/admins')
-          model = remote_controller.to_s.sub(%r{.*/}, '').singularize
           content_tag(:div, :class => 'active-scaffold-header') do
             content_tag(:h2) do
               label = options[:label] || begin

--- a/lib/active_scaffold/extensions/action_view_rendering.rb
+++ b/lib/active_scaffold/extensions/action_view_rendering.rb
@@ -149,8 +149,20 @@ module ActiveScaffold #:nodoc:
           model = remote_controller.to_s.sub(%r{.*/}, '').singularize
           content_tag(:div, :class => 'active-scaffold-header') do
             content_tag(:h2) do
-              link_label = options[:label] || active_scaffold_config_for(model).list.label
-              link_to(link_label, url, remote: true, class: 'load-embedded', data: {error_msg: as_(:error_500)}) <<
+              label = options[:label] || begin
+                # attempt to retrieve the active_scaffold_config by constantizing
+                # the controller path
+                controller_config = "#{remote_controller}_controller".camelize.constantize.active_scaffold_config rescue nil
+                controller_config.try(:label) || begin
+                  # if we couldn't determine the controller config by instantiating the
+                  # controller class, parse the ActiveRecord model name from the
+                  # controller path, which might be a namespaced controller (e.g., 'admin/admins')
+                  model = remote_controller.to_s.sub(%r{.*/}, '').singularize
+                  active_scaffold_config_for(model).list.label
+                end
+              end
+            
+              link_to(label, url, remote: true, class: 'load-embedded', data: {error_msg: as_(:error_500)}) <<
                 loading_indicator_tag(url_options)
             end
           end


### PR DESCRIPTION
When attempting to find the label for a controller rendered with the `render active_scaffold: 'path/to/controller'` helper, use the controller path to infer the scaffold controller, rather than parsing a model from the controller path, and then attempting to find the active scaffold config for that class.

Inferring the controller directly is preferable because there are cases where the controller name does not match the underlying model.  In this case when we parse the model from the controller name, we end up trying to constantize the wrong model class name, causing a NameError.

If we can't find the config from the controller name for some reason, fall back to the old behavior of pulling the model from the controller name and using active_scaffold_config_for(model)

Fixes activescaffold/active_scaffold/#711