### PR TITLE
Add support for dynamic form descriptions

### DIFF
--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -46,8 +46,10 @@ module ActiveScaffold::DataStructures
 
     # a textual description of the column and its contents. this will be displayed with any associated form input widget, so you may want to consider adding a content example.
     attr_writer :description
-    def description
-      if @description
+    def description(record=nil, scope=nil)
+      if @description&.respond_to?(:call)
+        @description.call(record, self, scope)
+      elsif @description
         @description
       else
         I18n.t name, :scope => [:activerecord, :description, active_record_class.to_s.underscore.to_sym], :default => ''

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -197,7 +197,7 @@ module ActiveScaffold
         end
         if field
           field << loading_indicator_tag(:action => :render_field, :id => params[:id]) if column.update_columns
-          field << content_tag(:span, column.description, :class => 'description') if column.description.present?
+          field << content_tag(:span, column.description(record, scope), :class => 'description') if column.description.present?
         end
 
         content_tag :dl, attributes do


### PR DESCRIPTION
allow a scaffold controller to define a column's description attribute as a Proc, such that the description content can change depending on the current record.  This is useful when another field in the form (such as a "type" dropdown) can change the context for the record enough that the description should now reflect different information.  This would typically be used in conjunction with a column that uses update_columns to re-render other fields when it changes.