### PR TITLE
Enable dynamic form labels

### DIFF
--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -40,8 +40,19 @@ module ActiveScaffold::DataStructures
     # the display-name of the column. this will be used, for instance, as the column title in the table and as the field name in the form.
     # if left alone it will utilize human_attribute_name which includes localization
     attr_writer :label
-    def label
-      as_(@label) || active_record_class.human_attribute_name(name.to_s)
+    def label(record=nil, scope=nil)
+      if @label.respond_to?(:call)
+        if record
+          @label.call(record, self, scope)
+        else
+          # sometimes label is called without a record in context (ie, from table
+          # headers).  In this case fall back to the humanized attribute name
+          # instead of the Proc
+          active_record_class.human_attribute_name(name.to_s)
+        end
+      else
+        as_(@label) || active_record_class.human_attribute_name(name.to_s)
+      end
     end
 
     # a textual description of the column and its contents. this will be displayed with any associated form input widget, so you may want to consider adding a content example.

--- a/lib/active_scaffold/data_structures/column.rb
+++ b/lib/active_scaffold/data_structures/column.rb
@@ -40,7 +40,7 @@ module ActiveScaffold::DataStructures
     # the display-name of the column. this will be used, for instance, as the column title in the table and as the field name in the form.
     # if left alone it will utilize human_attribute_name which includes localization
     attr_writer :label
-    def label(record=nil, scope=nil)
+    def label(record = nil, scope = nil)
       if @label.respond_to?(:call)
         if record
           @label.call(record, self, scope)

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -197,7 +197,7 @@ module ActiveScaffold
         end
         if field
           field << loading_indicator_tag(:action => :render_field, :id => params[:id]) if column.update_columns
-          field << content_tag(:span, column.description(record, scope), :class => 'description') if column.description(record, scope).present?
+          field << content_tag(:span, desc, :class => 'description') if desc = column.description(record, scope).presence
         end
 
         content_tag :dl, attributes do

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -201,7 +201,7 @@ module ActiveScaffold
         end
 
         content_tag :dl, attributes do
-          content_tag(:dt, label_tag(label_for(column, column_options), form_column_label(column))) <<
+          content_tag(:dt, label_tag(label_for(column, column_options), form_column_label(column, record: record, scope: scope))) <<
             content_tag(:dd, field)
         end
       end
@@ -210,8 +210,8 @@ module ActiveScaffold
         options[:id] unless column.form_ui == :select && column.association&.collection?
       end
 
-      def form_column_label(column)
-        column.label
+      def form_column_label(column, record: nil, scope: nil)
+        column.label(record, scope)
       end
 
       def subform_label(column, hidden)

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -197,11 +197,11 @@ module ActiveScaffold
         end
         if field
           field << loading_indicator_tag(:action => :render_field, :id => params[:id]) if column.update_columns
-          field << content_tag(:span, column.description(record, scope), :class => 'description') if column.description.present?
+          field << content_tag(:span, column.description(record, scope), :class => 'description') if column.description(record, scope).present?
         end
 
         content_tag :dl, attributes do
-          content_tag(:dt, label_tag(label_for(column, column_options), form_column_label(column, record: record, scope: scope))) <<
+          content_tag(:dt, label_tag(label_for(column, column_options), form_column_label(column, record, scope))) <<
             content_tag(:dd, field)
         end
       end
@@ -210,7 +210,7 @@ module ActiveScaffold
         options[:id] unless column.form_ui == :select && column.association&.collection?
       end
 
-      def form_column_label(column, record: nil, scope: nil)
+      def form_column_label(column, record = nil, scope = nil)
         column.label(record, scope)
       end
 

--- a/lib/active_scaffold/helpers/form_column_helpers.rb
+++ b/lib/active_scaffold/helpers/form_column_helpers.rb
@@ -197,7 +197,8 @@ module ActiveScaffold
         end
         if field
           field << loading_indicator_tag(:action => :render_field, :id => params[:id]) if column.update_columns
-          field << content_tag(:span, desc, :class => 'description') if desc = column.description(record, scope).presence
+          desc = column.description(record, scope)
+          field << content_tag(:span, desc, :class => 'description') if desc.present?
         end
 
         content_tag :dl, attributes do


### PR DESCRIPTION
This PR adds support for dynamically calling a Proc defined for a column's label attribute, similar to what was recently added for column descriptions.

The Proc is passed the record, column and scope for context.

Example, which changes the label between "API Key" and "Password" depending on the record:
```
    config.columns[:password].label = Proc.new { |record, column, scope| record.requires_api_key? ? 'API Key' : 'Password' }
```