### PR TITLE
Using `sum` on an array yields "Array can't be coerced into Integer"

### DIFF
--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -247,7 +247,7 @@ module ActiveScaffold
 
           message = options.include?(:message) ? options[:message] : as_('errors.template.body')
 
-          error_messages = objects.sum do |object|
+          error_messages = objects.map do |object|
             object.errors.full_messages.map do |msg|
               options[:list_type] != :br ? content_tag(:li, msg) : msg
             end

--- a/lib/active_scaffold/helpers/view_helpers.rb
+++ b/lib/active_scaffold/helpers/view_helpers.rb
@@ -247,7 +247,7 @@ module ActiveScaffold
 
           message = options.include?(:message) ? options[:message] : as_('errors.template.body')
 
-          error_messages = objects.map do |object|
+          error_messages = objects.sum([]) do |object|
             object.errors.full_messages.map do |msg|
               options[:list_type] != :br ? content_tag(:li, msg) : msg
             end


### PR DESCRIPTION
Using `sum` on an array of objects that are not numbers doesn't make any sense.   I'm baffled that this has actually worked all this time, but when upgrading from rails 6.1 to rails 7.1, this line started throwing an appropriate error:  " Array can't be coerced into Integer"

Changed to `map` and error messages look fine.