### PR TITLE
add support for Procs in action link labels

### DIFF
--- a/lib/active_scaffold/data_structures/action_link.rb
+++ b/lib/active_scaffold/data_structures/action_link.rb
@@ -77,8 +77,15 @@ module ActiveScaffold::DataStructures
 
     # what string to use to represent this action
     attr_writer :label
-    def label
-      @label.is_a?(Symbol) ? ActiveScaffold::Registry.cache(:translations, @label) { as_(@label) } : @label
+    def label(record=nil)
+      case @label
+      when Symbol
+        ActiveScaffold::Registry.cache(:translations, @label) { as_(@label) }
+      when Proc
+        @label.call(record)
+      else
+        @label
+      end
     end
 
     # image to use {:name => 'arrow.png', :size => '16x16'}

--- a/lib/active_scaffold/helpers/action_link_helpers.rb
+++ b/lib/active_scaffold/helpers/action_link_helpers.rb
@@ -68,7 +68,7 @@ module ActiveScaffold
             group_tag = :li
           end
           content = content_tag(group_tag, :class => html_classes.presence, :onclick => ('' if hover_via_click?)) do
-            content_tag(:div, as_(link.label), :class => link.name.to_s.downcase) << content_tag(:ul, content)
+            content_tag(:div, as_(link.label(record)), :class => link.name.to_s.downcase) << content_tag(:ul, content)
           end
         else
           content = render_action_link(link, record, options)
@@ -388,7 +388,7 @@ module ActiveScaffold
 
       def action_link_html(link, url, html_options, record)
         label = html_options.delete(:link)
-        label ||= link.label
+        label ||= link.label(record)
         if url.nil?
           content_tag(:a, label, html_options)
         else


### PR DESCRIPTION
This merge request would allow an action link's label to be a Proc or lambda, passing the record as the first argument.

Example usage:

```
config.nested.add_link(:accounts,
  :label => Proc.new { |record| "Accounts (%i)" % record.accounts.count })
```