### PR TITLE
Add additional time-related column formats to date_picker

### DIFF
--- a/lib/active_scaffold/bridges/date_picker/ext.rb
+++ b/lib/active_scaffold/bridges/date_picker/ext.rb
@@ -12,7 +12,7 @@ class ActiveScaffold::Bridges::DatePicker
       super
       return unless ActiveScaffold::Bridges::DatePicker.default_ui
 
-      date_picker_fields = _columns.collect { |c| {:name => c.name.to_sym, :type => c.type} if %i[date datetime].include?(c.type) }.compact
+      date_picker_fields = _columns.collect { |c| {:name => c.name.to_sym, :type => c.type} if %i[date datetime timestamp timestamptz].include?(c.type) }.compact
       # check to see if file column was used on the model
       return if date_picker_fields.empty?
 


### PR DESCRIPTION
When running on postgres, the types can be set to timestamp/timestamptz. This can also benefit from the datetime picker