### PR TITLE
Fix jquery ui datetime picker CSS and I18n

### DIFF
--- a/app/assets/stylesheets/active_scaffold.scss
+++ b/app/assets/stylesheets/active_scaffold.scss
@@ -6,8 +6,6 @@
 
  For details, see the ActiveScaffold web site: https://github.com/activescaffold/active_scaffold
 */
-@import 'active_scaffold_jquery_ui';
-@import 'active_scaffold_extensions';
 
 @import 'active_scaffold_layout';
 @import 'active_scaffold_images';

--- a/app/assets/stylesheets/active_scaffold.scss
+++ b/app/assets/stylesheets/active_scaffold.scss
@@ -5,10 +5,9 @@
  ActiveScaffold is freely distributable under the terms of an MIT-style license.
 
  For details, see the ActiveScaffold web site: https://github.com/activescaffold/active_scaffold
- *= require_self
- *= require "active_scaffold_jquery_ui"
- *= require "active_scaffold_extensions"
 */
+@import 'active_scaffold_jquery_ui';
+@import 'active_scaffold_extensions';
 
 @import 'active_scaffold_layout';
 @import 'active_scaffold_images';

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -151,3 +151,10 @@ en:
   time:
     formats:
       picker: "%a, %d %b %Y %H:%M:%S"
+  datetime:
+    prompts:
+      hour: Hour
+      minute: Minute
+      second: Second
+      millisec: Millisecond
+      microsec: Microsecond

--- a/lib/active_scaffold/bridges/date_picker/helper.rb
+++ b/lib/active_scaffold/bridges/date_picker/helper.rb
@@ -69,7 +69,9 @@ module ActiveScaffold::Bridges
           ampm: false,
           hourText: I18n.translate!('datetime.prompts.hour', locale: locale),
           minuteText: I18n.translate!('datetime.prompts.minute', locale: locale),
-          secondText: I18n.translate!('datetime.prompts.second', locale: locale)
+          secondText: I18n.translate!('datetime.prompts.second', locale: locale),
+          millisecText: I18n.translate!('datetime.prompts.millisec', locale: locale),
+          microsecText: I18n.translate!('datetime.prompts.microsec', locale: locale)
         }
 
         as_datetime_picker_options = I18n.translate! :datetime_picker_options, scope: :active_scaffold, locale: locale, default: ''


### PR DESCRIPTION
This works for me on Rails 7.2, otherwise this CSS does not load.

I also added translations for millisecond and microsecond.