### PR TITLE
Add ActiveStorage AttributeParams overrides

### DIFF
--- a/lib/active_scaffold/bridges/active_storage/attribute_params.rb
+++ b/lib/active_scaffold/bridges/active_storage/attribute_params.rb
@@ -1,0 +1,47 @@
+module ActiveScaffold
+  module Bridges
+    class ActiveStorage
+      module AttributeParams
+        private
+
+        def update_column_from_params(parent_record, column, attribute, avoid_changes = false)
+          return if skip_active_storage_assignment?(column, attribute)
+
+          super
+        end
+
+        def skip_active_storage_assignment?(column, attribute)
+          return false unless active_storage_form_ui?(column)
+
+          case column.form_ui
+          when :active_storage_has_one
+            attribute.blank?
+          when :active_storage_has_many
+            active_storage_values(attribute).empty?
+          else
+            false
+          end
+        end
+
+        def active_storage_form_ui?(column)
+          [:active_storage_has_one, :active_storage_has_many].include?(column.form_ui)
+        end
+
+        def active_storage_values(attribute)
+          collection =
+            case attribute
+            when ::ActionController::Parameters
+              attribute.to_unsafe_h.values
+            when Hash
+              attribute.values
+            else
+              Array(attribute)
+            end
+          collection.flatten.compact_blank
+        end
+      end
+    end
+  end
+end
+
+ActiveScaffold::AttributeParams.prepend ActiveScaffold::Bridges::ActiveStorage::AttributeParams


### PR DESCRIPTION
Fix an issue where updating a record via active scaffold which has active storage attachments (has_many :images), it removes any existing attachments even if the user has not selected "remove or replace files"

ActiveStorage bridge was missing a module that tells it to ignore the empty params (e.g. `record[images] = [""]`) 

TODO: at some point it might make sense to have the form submit the list of signed_id for the attached image to allow for individual file management rather than clearing all attachments and having to reupload the ones we want to keep